### PR TITLE
Fix typo in Quick Start

### DIFF
--- a/docs/source/quick_start.rst
+++ b/docs/source/quick_start.rst
@@ -45,8 +45,8 @@ Finally, you can build all.
 
 .. code:: bash
 
-   git clone https://github.com/dfir-iris/irisweb.git
-   cd irisweb
+   git clone https://github.com/dfir-iris/iris-web.git
+   cd iris-web
    # [... optionally, do some configuration as specified above ...]
    docker-compose build
    


### PR DESCRIPTION
The Quick Start section of the docs is pointing to the wrong GitHub repository : `https://github.com/dfir-iris/irisweb.git` instead of `https://github.com/dfir-iris/iris-web.git`.