### PR TITLE
Fix some typos in the authentication dos

### DIFF
--- a/docs/operations/access_control/authentication.md
+++ b/docs/operations/access_control/authentication.md
@@ -17,7 +17,7 @@ Passwords are stored salted and hashed, it is thus not possible to retrieve them
    
     ```python
     import bcrypt
-    print(bcrypt.hashpw('<new_password>'.encode('utf-8'), bcrypt.gensalt())
+    print(bcrypt.hashpw('<new_password>'.encode('utf-8'), bcrypt.gensalt()))
     ```
 
 2. Connect to the DB docker then the Postgresql database `iris_db` and update the password 

--- a/docs/operations/access_control/authentication.md
+++ b/docs/operations/access_control/authentication.md
@@ -30,6 +30,7 @@ Passwords are stored salted and hashed, it is thus not possible to retrieve them
     postgres=# UPDATE "user" SET password = '<hash>' WHERE "user".name = 'administrator';
     postgres=# \q
     exit
+    exit
     ```
 
 

--- a/docs/operations/access_control/authentication.md
+++ b/docs/operations/access_control/authentication.md
@@ -17,7 +17,7 @@ Passwords are stored salted and hashed, it is thus not possible to retrieve them
    
     ```python
     import bcrypt
-    print(bcrypt.hashpw(<new_password>.encode('utf-8'), bcrypt.gensalt())
+    print(bcrypt.hashpw('<new_password>'.encode('utf-8'), bcrypt.gensalt())
     ```
 
 2. Connect to the DB docker then the Postgresql database `iris_db` and update the password 

--- a/docs/operations/access_control/authentication.md
+++ b/docs/operations/access_control/authentication.md
@@ -28,6 +28,8 @@ Passwords are stored salted and hashed, it is thus not possible to retrieve them
     / # psql
     postgres=# \c iris_db 
     postgres=# UPDATE "user" SET password = '<hash>' WHERE "user".name = 'administrator';
+    postgres=# \q
+    exit
     ```
 
 


### PR DESCRIPTION
I needed to reset the admin password today and I noticed that the python command didn't work out of the box mostly because of missing parentheses.