### PR TITLE
Api v2 update task

### DIFF
--- a/docs/api_reference/reference/iris.v2.1.0.yaml
+++ b/docs/api_reference/reference/iris.v2.1.0.yaml
@@ -23,6 +23,7 @@ info:
     * Added GET /api/v2/cases/{case_identifier}/assets/{identifier}
     * Added DELETE /api/v2/cases/{case_identifier}/assets/{identifier}
     * Added GET /api/v2/cases/{case_identifier}/tasks/{identifier}
+    * Added PUT /api/v2/cases/{case_identifier}/tasks/{identifier}
     * Added DELETE /api/v2/cases/{case_identifier}/tasks/{identifier}
     * Added GET /api/v2/iocs/{identifier}
     * Added PUT /api/v2/iocs/{identifier}

--- a/docs/api_reference/reference/iris.v2.1.0.yaml
+++ b/docs/api_reference/reference/iris.v2.1.0.yaml
@@ -41,6 +41,7 @@ info:
     * Deprecated GET /case/ioc/{ioc_id}  in favor of GET /api/v2/iocs/{identifier}
     * Deprecated DELETE /case/ioc/delete/{ioc_id} in favor of DELETE /api/v2/iocs/{identifier}
     * Deprecated POST /case/tasks/add in favor of POST /api/v2/cases/{case_identifier}/tasks
+    * Deprecated POST /case/tasks/update/{task_id} in favor of PUT /api/v2/cases/{case_identifier}/tasks/{identifier}
     * Deprecated GET /case/tasks/{task_id} in favor of GET /api/v2/tasks/{identifier}
     * Deprecated DELETE /case/tasks/delete/{task_id} in favor of DELETE /api/v2/tasks/{identifier}
     * Deprecated POST /case/assets/add in favor of POST /api/v2/cases/{case_identifier}/assets

--- a/docs/api_reference/reference/v2.1.0/resources/api_v2_cases_{case_identifier}_tasks_{identifier}.yaml
+++ b/docs/api_reference/reference/v2.1.0/resources/api_v2_cases_{case_identifier}_tasks_{identifier}.yaml
@@ -17,6 +17,58 @@ get:
             $ref: ../schemas/Task.yaml
     '404':
       $ref: ../responses/NotFound.yaml
+put:
+  operationId: api_v2_cases_{case_identifier}_tasks_{identifier}_put
+  tags:
+    - Tasks
+    - Beta
+  summary: Update a task
+  description: Update an existing task of the case.
+  requestBody:
+    content:
+      application/json:
+        schema:
+          type: object
+          properties:
+            task_title:
+              type: string
+            task_description:
+              type: string
+            task_tags:
+              type: string
+            task_status_id:
+              type: integer
+            task_assignees_id:
+              type: array
+              items:
+                type: integer
+            custom_attributes:
+              type: object
+          required:
+            - task_assignees_id
+            - task_status_id
+            - task_title
+        examples:
+          example-1:
+            value:
+              task_assignees_id:
+                - 1
+              task_status_id: 1
+              task_title: New title
+              task_description: new content
+              task_tags: new tags
+              custom_attributes: {}
+  responses:
+    '200':
+      description: Task successfully updated
+      content:
+        application/json:
+          schema:
+            $ref: ../schemas/Task.yaml
+    '404':
+      $ref: ../responses/NotFound.yaml
+    '400':
+      $ref: ../responses/GenericError.yaml
 delete:
   operationId: api_v2_cases_{case_identifier}_tasks_{identifier}_delete
   tags:

--- a/docs/api_reference/reference/v2.1.0/resources/case_tasks_update_{task_id}.yaml
+++ b/docs/api_reference/reference/v2.1.0/resources/case_tasks_update_{task_id}.yaml
@@ -8,6 +8,8 @@ parameters:
 post:
   summary: Update a case task
   operationId: post-case-tasks-update
+  description: This endpoint is deprecated. Use PUT /api/v2/cases/{case_identifier}/tasks/{identifier} instead.
+  deprecated: true
   responses:
     '200':
       description: OK
@@ -160,7 +162,6 @@ post:
                 data: []
                 message: Invalid task ID for this case
                 status: error
-  description: Update an existing task of the case.
   requestBody:
     content:
       application/json:


### PR DESCRIPTION
This PR documents endpoint PUT /api/v2/cases/{case_identifier}/tasks/{identifier} and deprecates POST /case/tasks/update/{task_id} in the openapi documentation of the v2.1.0 API.