### PR TITLE
Api v2 get tasks

### DIFF
--- a/docs/api_reference/reference/iris.v2.1.0.yaml
+++ b/docs/api_reference/reference/iris.v2.1.0.yaml
@@ -41,6 +41,7 @@ info:
     * Deprecated POST /case/ioc/add in favor of POST /api/v2/cases/{case_identifier}/iocs
     * Deprecated GET /case/ioc/{ioc_id}  in favor of GET /api/v2/iocs/{identifier}
     * Deprecated DELETE /case/ioc/delete/{ioc_id} in favor of DELETE /api/v2/iocs/{identifier}
+    * Deprecated GET /case/tasks/list in favor of GET /api/v2/cases/{case_identifier}/tasks
     * Deprecated POST /case/tasks/add in favor of POST /api/v2/cases/{case_identifier}/tasks
     * Deprecated POST /case/tasks/update/{task_id} in favor of PUT /api/v2/cases/{case_identifier}/tasks/{identifier}
     * Deprecated GET /case/tasks/{task_id} in favor of GET /api/v2/tasks/{identifier}

--- a/docs/api_reference/reference/iris.v2.1.0.yaml
+++ b/docs/api_reference/reference/iris.v2.1.0.yaml
@@ -20,18 +20,19 @@ info:
     * Added GET /api/v2/cases/{case_identifier}/iocs/{identifier}
     * Added PUT /api/v2/cases/{case_identifier}/iocs/{identifier}
     * Added DELETE /api/v2/cases/{case_identifier}/iocs/{identifier}
-    * Added GET /api/v2/cases/{case_identifier}/assets/{identifier}
-    * Added DELETE /api/v2/cases/{case_identifier}/assets/{identifier}
-    * Added GET /api/v2/cases/{case_identifier}/tasks/{identifier}
-    * Added PUT /api/v2/cases/{case_identifier}/tasks/{identifier}
-    * Added DELETE /api/v2/cases/{case_identifier}/tasks/{identifier}
     * Added GET /api/v2/iocs/{identifier}
     * Added PUT /api/v2/iocs/{identifier}
     * Added DELETE /api/v2/iocs/{identifier}
     * Added POST /api/v2/cases/{case_identifier}/tasks
+    * Added GET /api/v2/cases/{case_identifier}/tasks
+    * Added GET /api/v2/cases/{case_identifier}/tasks/{identifier}
+    * Added PUT /api/v2/cases/{case_identifier}/tasks/{identifier}
+    * Added DELETE /api/v2/cases/{case_identifier}/tasks/{identifier}
     * Added GET /api/v2/tasks/{identifier}
     * Added DELETE /api/v2/tasks/{identifier}
     * Added POST /api/v2/cases/{case_identifier}/assets
+    * Added GET /api/v2/cases/{case_identifier}/assets/{identifier}
+    * Added DELETE /api/v2/cases/{case_identifier}/assets/{identifier}
     * Added GET /api/v2/assets/{identifier}
     * Added DELETE /api/v2/assets/{identifier}
     * Deprecated POST /manage/cases/add in favor of POST /api/v2/cases

--- a/docs/api_reference/reference/v2.1.0/resources/api_v2_cases_{case_identifier}_tasks.yaml
+++ b/docs/api_reference/reference/v2.1.0/resources/api_v2_cases_{case_identifier}_tasks.yaml
@@ -49,3 +49,22 @@ post:
     '400':
       $ref: ../responses/GenericError.yaml
   description: 'Add a new task.'
+get:
+  operationId: api_v2_cases_{identifier}_tasks_get
+  summary: Get a paginated list of tasks
+  description: Returns a paginated list of tasks.
+  parameters:
+    - $ref: ../parameters/query/page.yaml
+    - $ref: ../parameters/query/per_page.yaml
+    - $ref: ../parameters/query/order_by.yaml
+    - $ref: ../parameters/query/sort_dir.yaml
+  responses:
+    '200':
+      description: Paginated list of Tasks
+      content:
+        application/json:
+          schema:
+            $ref: ../schemas/Tasks.yaml
+  tags:
+    - Tasks
+    - Beta

--- a/docs/api_reference/reference/v2.1.0/resources/case_tasks_list.yaml
+++ b/docs/api_reference/reference/v2.1.0/resources/case_tasks_list.yaml
@@ -1,5 +1,7 @@
 get:
   summary: Get case tasks
+  description: This endpoint is deprecated. Use GET /api/v2/cases/{case_identifier}/tasks
+  deprecated: true
   tags:
     - Tasks
   responses:
@@ -405,7 +407,6 @@ get:
                     object_state: 120
                     object_last_update: '2024-01-07T13:57:05.599620'
   operationId: get-case-tasks-get
-  description: Get a list of all the tasks in the case
   security:
     - Bearer <bearer>: []
   parameters:

--- a/docs/api_reference/reference/v2.1.0/schemas/Tasks.yaml
+++ b/docs/api_reference/reference/v2.1.0/schemas/Tasks.yaml
@@ -1,0 +1,17 @@
+type: object
+properties:
+  total:
+    type: integer
+  data:
+    type: array
+    items:
+      $ref: ../schemas/Task.yaml
+  last_page:
+    type: integer
+  current_page:
+    type: integer
+  next_page:
+    type: 
+      - integer
+      - null
+


### PR DESCRIPTION
This PR documents endpoint GET /api/v2/cases/{case_identifier}/tasks.
It also deprecates endpoint GET /case/tasks/list.