### PR TITLE
Api v2 create note

### DIFF
--- a/docs/api_reference/reference/iris.v2.1.0.yaml
+++ b/docs/api_reference/reference/iris.v2.1.0.yaml
@@ -53,6 +53,7 @@ info:
     * Deprecated POST /case/assets/update/{cur_id} in favor of PUT /api/v2/cases/{case_identifier}/assets/{identifier}
     * Deprecated GET /case/assets/{asset_id} in favor of GET /api/v2/assets/{identifier}
     * Deprecated DELETE /case/assets/delete/{asset_id} in favor of DELETE /api/v2/assets/{identifier}
+    * Deprecated POST /case/notes/add in favor of POST /api/v2/cases/{case_identifier}/notes
     * Added documentation of missing GET /manage/severities/list
     * Added documentation of missing GET /manage/tlp/list
     * Added documentation of missing GET /manage/event-categories/list

--- a/docs/api_reference/reference/iris.v2.1.0.yaml
+++ b/docs/api_reference/reference/iris.v2.1.0.yaml
@@ -35,6 +35,7 @@ info:
     * Added GET /api/v2/cases/{case_identifier}/assets/{identifier}
     * Added PUT /api/v2/cases/{case_identifier}/assets/{identifier}
     * Added DELETE /api/v2/cases/{case_identifier}/assets/{identifier}
+    * Added POST /api/v2/cases/{case_identifier}/notes
     * Added GET /api/v2/assets/{identifier}
     * Added DELETE /api/v2/assets/{identifier}
     * Deprecated POST /manage/cases/add in favor of POST /api/v2/cases
@@ -88,6 +89,8 @@ paths:
     $ref: v2.1.0/resources/api_v2_cases_{case_identifier}_assets.yaml
   /api/v2/cases/{case_identifier}/assets/{identifier}:
     $ref: v2.1.0/resources/api_v2_cases_{case_identifier}_assets_{identifier}.yaml
+  /api/v2/cases/{case_identifier}/notes:
+    $ref: v2.1.0/resources/api_v2_cases_{case_identifier}_notes.yaml
   /api/v2/cases/{case_identifier}/tasks:
     $ref: v2.1.0/resources/api_v2_cases_{case_identifier}_tasks.yaml
   /api/v2/cases/{case_identifier}/tasks/{identifier}:

--- a/docs/api_reference/reference/v2.1.0/resources/api_v2_cases_{case_identifier}_notes.yaml
+++ b/docs/api_reference/reference/v2.1.0/resources/api_v2_cases_{case_identifier}_notes.yaml
@@ -36,6 +36,8 @@ post:
             $ref: ../schemas/Note.yaml
     '400':
       $ref: ../responses/GenericError.yaml
+    '404':
+      description: Case with identifier case_identifier not found
 
 
 

--- a/docs/api_reference/reference/v2.1.0/resources/api_v2_cases_{case_identifier}_notes.yaml
+++ b/docs/api_reference/reference/v2.1.0/resources/api_v2_cases_{case_identifier}_notes.yaml
@@ -1,0 +1,41 @@
+parameters:
+  - $ref: ../parameters/path/case_identifier.yaml
+post:
+  operationId: api_v2_cases_{identifier}_notes_post
+  summary: Add a new note
+  tags:
+    - Notes
+    - Beta
+  description: Add a new note to an existing group.
+  requestBody:
+    content:
+      application/json:
+        schema:
+          type: object
+          properties:
+            note_title:
+              type: string
+            note_content:
+              type: string
+            directory_id:
+              type: integer
+          required:
+            - directory_id
+        examples:
+          example-1:
+            value:
+              note_title: Title of the note
+              note_content: Content of the note
+              directory_id: 36
+  responses:
+    '201':
+      description: Note successfully created
+      content:
+        application/json:
+          schema:
+            $ref: ../schemas/Note.yaml
+    '400':
+      $ref: ../responses/GenericError.yaml
+
+
+

--- a/docs/api_reference/reference/v2.1.0/resources/case_notes_add.yaml
+++ b/docs/api_reference/reference/v2.1.0/resources/case_notes_add.yaml
@@ -2,6 +2,8 @@ parameters: []
 post:
   summary: Add a new note
   operationId: post-case-notes-add
+  description: This endpoint is deprecated. Use POST /api/v2/cases/{case_identifier}/notes instead.
+  deprecated: true
   tags:
     - Notes
   responses:
@@ -164,7 +166,6 @@ post:
                     - Missing data for required field.
                 message: Data error
                 status: error
-  description: 'Add a new note to an existing group. '
   parameters:
     - schema:
         type: integer

--- a/docs/api_reference/reference/v2.1.0/schemas/Note.yaml
+++ b/docs/api_reference/reference/v2.1.0/schemas/Note.yaml
@@ -35,6 +35,8 @@ properties:
     type: string
   note_case_id:
     type: integer
+  modification_history:
+    $ref: ../schemas/modification_history.yaml
 example:
   note_id: 16
   note_uuid: ecbbd74e-85fd-4268-a9a4-c069677e6677
@@ -50,4 +52,8 @@ example:
   note_creationdate: '2024-03-27T18:14:21.245694'
   note_lastupdate: '2024-03-27T18:14:21.245724'
   note_case_id: 1
-  
+  modification_history:
+    user: 'administrator'
+    user_id: 1
+    action: 'created note'
+

--- a/docs/api_reference/reference/v2.1.0/schemas/Note.yaml
+++ b/docs/api_reference/reference/v2.1.0/schemas/Note.yaml
@@ -1,0 +1,53 @@
+type: object
+properties:
+  note_id:
+    type: integer
+  note_uuid:
+    type: string
+  note_title:
+    type:
+      - string
+      - 'null'
+  note_content:
+    type:
+      - string
+      - 'null'
+  directory_id:
+    type: integer
+  directory:
+    type: object
+    properties:
+      id:
+        type: integer
+      name:
+        type: string
+      parent_id:
+        type: 
+          - integer
+          - 'null'
+      case_id:
+        type: integer
+  note_user:
+    type: integer
+  note_creationdate:
+    type: string
+  note_lastupdate:
+    type: string
+  note_case_id:
+    type: integer
+example:
+  note_id: 16
+  note_uuid: ecbbd74e-85fd-4268-a9a4-c069677e6677
+  note_title: Title of the note
+  note_content: Content of the note
+  directory_id: 2
+  directory:
+    id: 2
+    name: A dir
+    parent_id: null
+    case_id: 1
+  note_user: 1
+  note_creationdate: '2024-03-27T18:14:21.245694'
+  note_lastupdate: '2024-03-27T18:14:21.245724'
+  note_case_id: 1
+  

--- a/docs/api_reference/reference/v2.1.0/schemas/modification_history.yaml
+++ b/docs/api_reference/reference/v2.1.0/schemas/modification_history.yaml
@@ -1,0 +1,12 @@
+type: object
+additionalProperties:
+  x-additionalPropertiesName: string timestamp
+  type: object
+  properties:
+    user:
+      type: string
+    user_id:
+      type: integer
+    action:
+      type: string
+


### PR DESCRIPTION
Documentation of endpoint `POST /api/v2/cases/{case_identifier}/notes`.
Deprecation of `POST /case/notes/add`.
Creation of schema `Note.yaml` and `modification_history.yaml`, to factor documentation somewhat.