### PR TITLE
Api v2 create evidence

### DIFF
--- a/docs/api_reference/reference/.redocly.lint-ignore.yaml
+++ b/docs/api_reference/reference/.redocly.lint-ignore.yaml
@@ -36,12 +36,6 @@ v2.1.0/resources/api_v2_cases_{case_identifier}_assets_{identifier}.yaml:
 v2.1.0/resources/api_v2_cases_{case_identifier}_tasks.yaml:
   operation-4xx-response:
     - '#/get/responses'
-v2.1.0/resources/manage_cases_update_{case_id}.yaml:
-  struct:
-    - >-
-      #/post/responses/200/content/application~1json/schema/properties/data/properties/closing_note/nullable
-  no-invalid-media-type-examples:
-    - '#/post/responses/200/content/application~1json/schema'
 v2.1.0/resources/case_summary_update.yaml:
   no-invalid-media-type-examples:
     - '#/post/requestBody/content/application~1json/examples/example-1/value/cid'

--- a/docs/api_reference/reference/iris.v2.1.0.yaml
+++ b/docs/api_reference/reference/iris.v2.1.0.yaml
@@ -41,6 +41,7 @@ info:
     * Added GET /api/v2/cases/{case_identifier}/notes/{identifier}
     * Added PUT /api/v2/cases/{case_identifier}/notes/{identifier}
     * Added DELETE /api/v2/cases/{case_identifier}/notes/{identifier}
+    * Added POST /api/v2/cases/{case_identifier}/evidences
     * Deprecated POST /manage/cases/add in favor of POST /api/v2/cases
     * Deprecated POST /manage/cases/update in favor of PUT /api/v2/cases/{case_identifier}
     * Deprecated POST /manage/cases/delete/{case_id} in favor of DELETE /api/v2/cases/{case_identifier}
@@ -105,6 +106,8 @@ paths:
     $ref: v2.1.0/resources/api_v2_cases_{case_identifier}_tasks.yaml
   /api/v2/cases/{case_identifier}/tasks/{identifier}:
     $ref: v2.1.0/resources/api_v2_cases_{case_identifier}_tasks_{identifier}.yaml
+  /api/v2/cases/{case_identifier}/evidences:
+    $ref: v2.1.0/resources/api_v2_cases_{case_identifier}_evidences.yaml
   /manage/cases/update/{case_id}:
     $ref: v2.1.0/resources/manage_cases_update_{case_id}.yaml
   /api/v2/iocs/{identifier}:

--- a/docs/api_reference/reference/iris.v2.1.0.yaml
+++ b/docs/api_reference/reference/iris.v2.1.0.yaml
@@ -61,6 +61,7 @@ info:
     * Deprecated GET /case/notes/{identifier} in favor of GET /api/v2/cases/{case_identifier}/notes/{identifier}
     * Deprecated POST /case/notes/update/{node_id} in favor of PUT /api/v2/cases/{case_identifier}/notes/{identifier}
     * Deprecated POST /case/notes/delete/{node_id} in favor of DELETE /api/v2/cases/{case_identifier}/notes/{identifier}
+    * Deprecated POST /case/evidences/add in favor of POST /api/v2/cases/{case_identifier}/evidences
     * Added documentation of missing GET /manage/severities/list
     * Added documentation of missing GET /manage/tlp/list
     * Added documentation of missing GET /manage/event-categories/list

--- a/docs/api_reference/reference/v2.1.0/resources/api_v2_cases_{case_identifier}_evidences.yaml
+++ b/docs/api_reference/reference/v2.1.0/resources/api_v2_cases_{case_identifier}_evidences.yaml
@@ -1,0 +1,53 @@
+parameters:
+  - $ref: ../parameters/path/case_identifier.yaml
+post:
+  operationId: api_v2_cases_(identifier)_evidences_post
+  summary: Add an evidence
+  description: Add a new evidence to the case.
+  tags:
+    - Evidences
+    - Beta
+  requestBody:
+    content:
+      application/json:
+        schema:
+          type: object
+          properties:
+            filename:
+              type: string
+            file_size:
+              type: integer
+            file_hash:
+              type: string
+            type_id:
+              type: integer
+            start_date:
+              $ref: ../schemas/iso_date.yaml
+            end_date:
+              $ref: ../schemas/iso_date.yaml
+            file_description:
+              type: string
+          required:
+            - filename
+        examples:
+          example-1:
+            value:
+              filename: dummy file
+              file_size: 77108
+              file_hash: 88BC9EF6F07F0FAE922AB25EB226906542F8BA0DC1A221F3EA7273CBCB5DB0D4
+              type_id: 2
+              start_date: '2024-04-13T03:02:00'
+              end_date: '2024-04-04T00:00:00'
+              file_description: 'Dummy description'
+  responses:
+    '201':
+      description: Evidence successfully created
+      content:
+        application/json:
+          schema:
+            $ref: ../schemas/Evidence.yaml
+    '400':
+      $ref: ../responses/GenericError.yaml
+    '404':
+      description: Case with identifier case_identifier not found
+

--- a/docs/api_reference/reference/v2.1.0/resources/api_v2_cases_{case_identifier}_notes.yaml
+++ b/docs/api_reference/reference/v2.1.0/resources/api_v2_cases_{case_identifier}_notes.yaml
@@ -3,10 +3,10 @@ parameters:
 post:
   operationId: api_v2_cases_(identifier)_notes_post
   summary: Add a new note
+  description: Add a new note to an existing group.
   tags:
     - Notes
     - Beta
-  description: Add a new note to an existing group.
   requestBody:
     content:
       application/json:
@@ -38,6 +38,4 @@ post:
       $ref: ../responses/GenericError.yaml
     '404':
       description: Case with identifier case_identifier not found
-
-
 

--- a/docs/api_reference/reference/v2.1.0/resources/case_evidences_add.yaml
+++ b/docs/api_reference/reference/v2.1.0/resources/case_evidences_add.yaml
@@ -1,6 +1,8 @@
 post:
   summary: Add an evidence
   operationId: post-case-add-evidence
+  description: This endpoint is deprecated. Use [POST /api/v2/cases/{case_identifier}/evidences](#tag/Evidences/operation/api_v2_cases_(identifier)_evidences_post) instead.
+  deprecated: true
   responses:
     '200':
       description: OK
@@ -144,7 +146,6 @@ post:
                   file_size: 0
                   end_date: null
                   file_description: string
-  description: Add a new evidence to the case.
   parameters:
     - schema:
         type: integer

--- a/docs/api_reference/reference/v2.1.0/resources/manage_cases_update_{case_id}.yaml
+++ b/docs/api_reference/reference/v2.1.0/resources/manage_cases_update_{case_id}.yaml
@@ -92,7 +92,7 @@ post:
                   case_description:
                     type: string
                   closing_note:
-                    nullable: true
+                    type: 'null'
                   close_date:
                     type:
                       - string

--- a/docs/api_reference/reference/v2.1.0/schemas/Evidence.yaml
+++ b/docs/api_reference/reference/v2.1.0/schemas/Evidence.yaml
@@ -57,6 +57,10 @@ properties:
     type:
       - string
       - 'null'
+  modification_history:
+    anyOf:
+      - $ref: ../schemas/modification_history.yaml
+      - type: 'null'
 example:
   chain_of_custody: null
   case_id: 1
@@ -80,4 +84,4 @@ example:
     user_email: administrator@iris.local
   file_size: 0
   file_description: 'File description'
-
+  modification_history: null

--- a/docs/api_reference/reference/v2.1.0/schemas/Evidence.yaml
+++ b/docs/api_reference/reference/v2.1.0/schemas/Evidence.yaml
@@ -1,0 +1,83 @@
+type: object
+properties:
+  chain_of_custody:
+    type: 'null'
+  case_id:
+    type: integer
+  type_id:
+    type: 
+      - integer
+      - 'null'
+  id:
+    type: integer
+  file_hash:
+    type:
+      - string
+      - 'null'
+  filename:
+    type: string
+  start_date:
+    anyOf:
+      - $ref: ../schemas/iso_date.yaml
+      - type: 'null'
+  end_date:
+    anyOf:
+      - $ref: ../schemas/iso_date.yaml
+      - type: 'null'
+  type:
+    type: 'null'
+  acquisition_date:
+    type: 'null'
+  case:
+    type: integer
+  file_uuid:
+    type: string
+  user_id:
+    type: integer
+  custom_attributes:
+    type: object
+  date_added:
+    $ref: ../schemas/iso_date.yaml
+  user:
+    type: object
+    properties:
+      id:
+        type: integer
+      user_name:
+        type: string
+      user_login:
+        type: string
+      user_email:
+        type: string
+  file_size:
+    type:
+      - integer
+      - 'null'
+  file_description:
+    type:
+      - string
+      - 'null'
+example:
+  chain_of_custody: null
+  case_id: 1
+  type_id: null
+  id: 119
+  file_hash: 88BC9EF6F07F0FAE922AB25EB226906542F8BA0DC1A221F3EA7273CBCB5DB0D4
+  filename: filename.ext
+  start_date: null
+  end_date: null
+  type: null
+  acquisition_date: null
+  case: 1
+  file_uuid: 2c322eb0-53be-45c7-b71c-ae5bc4c3bd0a
+  user_id: 1
+  custom_attributes: {}
+  date_added: '2024-01-11T07:39:11.211407'
+  user:
+    id: 1
+    user_name: administrator
+    user_login: administrator
+    user_email: administrator@iris.local
+  file_size: 0
+  file_description: 'File description'
+

--- a/docs/api_reference/reference/v2.1.0/schemas/Note.yaml
+++ b/docs/api_reference/reference/v2.1.0/schemas/Note.yaml
@@ -53,7 +53,8 @@ example:
   note_lastupdate: '2024-03-27T18:14:21.245724'
   note_case_id: 1
   modification_history:
-    user: 'administrator'
-    user_id: 1
-    action: 'created note'
+    '1711563261.268616':
+      user: 'administrator'
+      user_id: 1
+      action: 'created note'
 


### PR DESCRIPTION
* Documentation of endpoint `POST /api/v2/cases/{case_identifier}/evidences`.
* Deprecation of `POST /case/evidences/add`
* Creation of schema `Evidence.yaml`, to factor.
* quality: fixed a struct error reported by redocly lint
