### PR TITLE
Api v2 update evidence

### DIFF
--- a/docs/api_reference/reference/.redocly.lint-ignore.yaml
+++ b/docs/api_reference/reference/.redocly.lint-ignore.yaml
@@ -544,14 +544,6 @@ v2.1.0/resources/global_tasks_add.yaml:
   no-invalid-media-type-examples:
     - >-
       #/post/responses/200/content/application~1json/examples/Success/value/data/task_userid_open
-v2.1.0/resources/global_tasks_update_{task_id}.yaml:
-  struct:
-    - >-
-      #/post/responses/200/content/application~1json/schema/properties/data/properties/task_close_date/nullable
-    - >-
-      #/post/responses/200/content/application~1json/schema/properties/data/properties/task_userid_close/nullable
-    - >-
-      #/post/responses/200/content/application~1json/schema/properties/data/properties/task_userid_open/nullable
 v2.1.0/resources/manage_cases_add.yaml:
   no-invalid-media-type-examples:
     - >-

--- a/docs/api_reference/reference/.redocly.lint-ignore.yaml
+++ b/docs/api_reference/reference/.redocly.lint-ignore.yaml
@@ -285,8 +285,6 @@ v2.1.0/resources/alerts_add.yaml:
   struct:
     - '#/post/responses/'
     - >-
-      #/post/responses/200/content/application~1json/schema/properties/data/properties/owner/nullable
-    - >-
       #/post/responses/200/content/application~1json/schema/properties/data/properties/assets/items/properties/user_id/nullable
     - >-
       #/post/responses/200/content/application~1json/schema/properties/data/properties/assets/items/properties/case_id/nullable
@@ -310,18 +308,6 @@ v2.1.0/resources/alerts_add.yaml:
       #/post/responses/200/content/application~1json/schema/properties/data/properties/iocs/items/properties/custom_attributes/nullable
     - >-
       #/post/responses/200/content/application~1json/schema/properties/data/properties/iocs/items/properties/ioc_type/properties/type_validation_regex/nullable
-    - >-
-      #/post/responses/200/content/application~1json/schema/properties/data/properties/iocs/items/properties/ioc_type/properties/type_validation_expect/nullable
-    - >-
-      #/post/responses/200/content/application~1json/schema/properties/data/properties/iocs/items/properties/ioc_type/properties/type_taxonomy/nullable
-    - >-
-      #/post/responses/200/content/application~1json/schema/properties/data/properties/customer/properties/customer_sla/nullable
-    - >-
-      #/post/responses/200/content/application~1json/schema/properties/data/properties/customer/properties/customer_description/nullable
-    - >-
-      #/post/responses/200/content/application~1json/schema/properties/data/properties/customer/properties/custom_attributes/nullable
-    - >-
-      #/post/responses/200/content/application~1json/schema/properties/data/properties/alert_owner_id/nullable
   operation-4xx-response:
     - '#/post/responses'
   no-invalid-media-type-examples:

--- a/docs/api_reference/reference/.redocly.lint-ignore.yaml
+++ b/docs/api_reference/reference/.redocly.lint-ignore.yaml
@@ -120,10 +120,6 @@ v2.1.0/resources/case_export.yaml:
 v2.1.0/resources/case_assets_list.yaml:
   operation-4xx-response:
     - '#/get/responses'
-v2.1.0/resources/case_assets_delete_{asset_id}.yaml:
-  struct:
-    - >-
-      #/post/responses/200/content/application~1json/schema/properties/value/properties/data/items/nullable
 v2.1.0/resources/case_notes_groups_list.yaml:
   operation-4xx-response:
     - '#/get/responses'

--- a/docs/api_reference/reference/.redocly.lint-ignore.yaml
+++ b/docs/api_reference/reference/.redocly.lint-ignore.yaml
@@ -120,10 +120,6 @@ v2.1.0/resources/case_export.yaml:
 v2.1.0/resources/case_assets_list.yaml:
   operation-4xx-response:
     - '#/get/responses'
-v2.1.0/resources/case_assets_{asset_id}.yaml:
-  struct:
-    - >-
-      #/get/responses/400/content/application~1json/schema/properties/data/items/nullable
 v2.1.0/resources/case_assets_delete_{asset_id}.yaml:
   struct:
     - >-

--- a/docs/api_reference/reference/iris.v2.1.0.yaml
+++ b/docs/api_reference/reference/iris.v2.1.0.yaml
@@ -64,6 +64,7 @@ info:
     * Deprecated POST /case/notes/update/{node_id} in favor of PUT /api/v2/cases/{case_identifier}/notes/{identifier}
     * Deprecated POST /case/notes/delete/{node_id} in favor of DELETE /api/v2/cases/{case_identifier}/notes/{identifier}
     * Deprecated POST /case/evidences/add in favor of POST /api/v2/cases/{case_identifier}/evidences
+    * Deprecated GET /case/evidences/list in favor of GET /api/v2/cases/{case_identifier}/evidences
     * Deprecated POST /case/evidences/{evidence_id} in favor of POST /api/v2/cases/{case_identifier}/evidences/{identifier}
     * Added documentation of missing GET /manage/severities/list
     * Added documentation of missing GET /manage/tlp/list

--- a/docs/api_reference/reference/iris.v2.1.0.yaml
+++ b/docs/api_reference/reference/iris.v2.1.0.yaml
@@ -42,6 +42,7 @@ info:
     * Added PUT /api/v2/cases/{case_identifier}/notes/{identifier}
     * Added DELETE /api/v2/cases/{case_identifier}/notes/{identifier}
     * Added POST /api/v2/cases/{case_identifier}/evidences
+    * Added GET /api/v2/cases/{case_identifier}/evidences
     * Added GET /api/v2/cases/{case_identifier}/evidences/{identifier}
     * Deprecated POST /manage/cases/add in favor of POST /api/v2/cases
     * Deprecated POST /manage/cases/update in favor of PUT /api/v2/cases/{case_identifier}

--- a/docs/api_reference/reference/iris.v2.1.0.yaml
+++ b/docs/api_reference/reference/iris.v2.1.0.yaml
@@ -66,7 +66,8 @@ info:
     * Deprecated POST /case/notes/delete/{node_id} in favor of DELETE /api/v2/cases/{case_identifier}/notes/{identifier}
     * Deprecated POST /case/evidences/add in favor of POST /api/v2/cases/{case_identifier}/evidences
     * Deprecated GET /case/evidences/list in favor of GET /api/v2/cases/{case_identifier}/evidences
-    * Deprecated POST /case/evidences/{evidence_id} in favor of POST /api/v2/cases/{case_identifier}/evidences/{identifier}
+    * Deprecated GET /case/evidences/{evidence_id} in favor of GET /api/v2/cases/{case_identifier}/evidences/{identifier}
+    * Deprecated POST /case/evidences/udpate/{evidence_id} in favor of PUT /api/v2/cases/{case_identifier}/evidences/{identifier}
     * Added documentation of missing GET /manage/severities/list
     * Added documentation of missing GET /manage/tlp/list
     * Added documentation of missing GET /manage/event-categories/list

--- a/docs/api_reference/reference/iris.v2.1.0.yaml
+++ b/docs/api_reference/reference/iris.v2.1.0.yaml
@@ -44,6 +44,7 @@ info:
     * Added POST /api/v2/cases/{case_identifier}/evidences
     * Added GET /api/v2/cases/{case_identifier}/evidences
     * Added GET /api/v2/cases/{case_identifier}/evidences/{identifier}
+    * Added PUT /api/v2/cases/{case_identifier}/evidences/{identifier}
     * Deprecated POST /manage/cases/add in favor of POST /api/v2/cases
     * Deprecated POST /manage/cases/update in favor of PUT /api/v2/cases/{case_identifier}
     * Deprecated POST /manage/cases/delete/{case_id} in favor of DELETE /api/v2/cases/{case_identifier}

--- a/docs/api_reference/reference/v2.1.0/resources/alerts_add.yaml
+++ b/docs/api_reference/reference/v2.1.0/resources/alerts_add.yaml
@@ -218,7 +218,9 @@ post:
                 type: object
                 properties:
                   owner:
-                    nullable: true
+                    type:
+                      - object
+                      - 'null'
                   alert_note:
                     type: string
                   alert_source:
@@ -348,9 +350,13 @@ post:
                             type_description:
                               type: string
                             type_validation_expect:
-                              nullable: true
+                              type:
+                                - string
+                                - 'null'
                             type_taxonomy:
-                              nullable: true
+                              type:
+                                - string
+                                - 'null'
                         ioc_tags:
                           type: string
                   alert_context:
@@ -376,19 +382,27 @@ post:
                       client_uuid:
                         type: string
                       customer_sla:
-                        nullable: true
+                        type:
+                          - string
+                          - 'null'
                       last_update_date:
                         type: string
                       customer_id:
                         type: integer
                       customer_description:
-                        nullable: true
+                        type:
+                          - string
+                          - 'null'
                       custom_attributes:
-                        nullable: true
+                        type:
+                          - object
+                          - 'null'
                       creation_date:
                         type: string
                   alert_owner_id:
-                    nullable: true
+                    type:
+                      - integer
+                      - 'null'
                   alert_description:
                     type: string
                   alert_creation_time:

--- a/docs/api_reference/reference/v2.1.0/resources/api_v2_cases_{case_identifier}_evidences.yaml
+++ b/docs/api_reference/reference/v2.1.0/resources/api_v2_cases_{case_identifier}_evidences.yaml
@@ -66,6 +66,12 @@ get:
         application/json:
           schema:
             $ref: ../schemas/Evidences.yaml
+    '400':
+      $ref: ../responses/GenericError.yaml
+    '403':
+      description: Insufficient rights
+    '404':
+      $ref: ../responses/NotFound.yaml
   tags:
     - Evidences
     - Beta

--- a/docs/api_reference/reference/v2.1.0/resources/api_v2_cases_{case_identifier}_evidences.yaml
+++ b/docs/api_reference/reference/v2.1.0/resources/api_v2_cases_{case_identifier}_evidences.yaml
@@ -69,7 +69,7 @@ get:
     '400':
       $ref: ../responses/GenericError.yaml
     '403':
-      description: Insufficient rights
+      $ref: ../responses/Forbidden.yaml
     '404':
       $ref: ../responses/NotFound.yaml
   tags:

--- a/docs/api_reference/reference/v2.1.0/resources/api_v2_cases_{case_identifier}_evidences.yaml
+++ b/docs/api_reference/reference/v2.1.0/resources/api_v2_cases_{case_identifier}_evidences.yaml
@@ -50,4 +50,22 @@ post:
       $ref: ../responses/GenericError.yaml
     '404':
       description: Case with identifier case_identifier not found
-
+get:
+  operationId: api_v2_cases_(case_identifier)_evidences_get
+  summary: Get a paginated list of evidences
+  description: Returns a paginated list of evidences.
+  parameters:
+    - $ref: ../parameters/query/page.yaml
+    - $ref: ../parameters/query/per_page.yaml
+    - $ref: ../parameters/query/order_by.yaml
+    - $ref: ../parameters/query/sort_dir.yaml
+  responses:
+    '200':
+      description: Paginated list of evidences
+      content:
+        application/json:
+          schema:
+            $ref: ../schemas/Evidences.yaml
+  tags:
+    - Evidences
+    - Beta

--- a/docs/api_reference/reference/v2.1.0/resources/api_v2_cases_{case_identifier}_evidences_{identifier}.yaml
+++ b/docs/api_reference/reference/v2.1.0/resources/api_v2_cases_{case_identifier}_evidences_{identifier}.yaml
@@ -17,4 +17,57 @@ get:
             $ref: ../schemas/Evidence.yaml
     '404':
       $ref: ../responses/NotFound.yaml
+put:
+  operationId: api_v2_cases_(case_identifier)_evidences_(identifier)_put
+  tags:
+    - Evidences
+    - Beta
+  summary: Update an evidence
+  description: Update an evidence.
+  requestBody:
+    content:
+      application/json:
+        schema:
+          type: object
+          properties:
+            filename:
+              type: string
+            file_description:
+              type: string
+            file_size:
+              type: integer
+            file_hash:
+              type: string
+            type_id:
+              $ref: ../schemas/evidence_type_id.yaml
+            start_date:
+              $ref: ../schemas/iso_date.yaml
+            end_date:
+              $ref: ../schemas/iso_date.yaml
+            custom_attributes:
+              type: object
+        examples:
+          example-1:
+            value:
+              filename: 'dummy file'
+              file_size: 77108
+              file_hash: 88BC9EF6F07F0FAE922AB25EB226906542F8BA0DC1A221F3EA7273CBCB5DB0D4
+              type_id: 2
+              start_date: '2024-04-13T03:02:00.000'
+              end_date: '2024-04-04T00:00:00.000'
+              custom_attributes: {}
+              file_description: Dummy description
+  responses:
+    '200':
+      description: Evidence successfully updated
+      content:
+        application/json:
+          schema:
+            $ref: ../schemas/Evidence.yaml
+    '403':
+      $ref: ../responses/Forbidden.yaml
+    '404':
+      $ref: ../responses/NotFound.yaml
+    '400':
+      $ref: ../responses/GenericError.yaml
 

--- a/docs/api_reference/reference/v2.1.0/resources/case_assets_delete_{asset_id}.yaml
+++ b/docs/api_reference/reference/v2.1.0/resources/case_assets_delete_{asset_id}.yaml
@@ -111,11 +111,12 @@ post:
                 type: object
                 properties:
                   data:
-                    type: array
+                    type:
+                      - array
+                      - 'null'
                     items:
                       type: object
                       additionalProperties: false
-                      nullable: true
                   message:
                     type: string
                   status:

--- a/docs/api_reference/reference/v2.1.0/resources/case_assets_{asset_id}.yaml
+++ b/docs/api_reference/reference/v2.1.0/resources/case_assets_{asset_id}.yaml
@@ -255,8 +255,9 @@ get:
               data:
                 type: array
                 items:
-                  type: object
-                  nullable: true
+                  type:
+                    - object
+                    - 'null'
               message:
                 type: string
               status:

--- a/docs/api_reference/reference/v2.1.0/resources/case_evidences_list.yaml
+++ b/docs/api_reference/reference/v2.1.0/resources/case_evidences_list.yaml
@@ -1,5 +1,8 @@
 get:
   summary: Get case evidences
+  operationId: get-case-evidences-list
+  description: This endpoint is deprecated. Use [GET /api/v2/cases/{case_identifier}/evidences](#tag/Evidences/operation/api_v2_cases_(case_identifier)_evidences_get) instead.
+  deprecated: true
   tags:
     - Evidences
   responses:
@@ -324,8 +327,6 @@ get:
                   state:
                     object_state: 20
                     object_last_update: '2024-01-07T13:40:47.236614'
-  operationId: get-case-evidences-list
-  description: 'Returns a list of all evidences linked to the case. '
   parameters:
     - schema:
         type: integer

--- a/docs/api_reference/reference/v2.1.0/resources/case_evidences_update_{evidence_id}.yaml
+++ b/docs/api_reference/reference/v2.1.0/resources/case_evidences_update_{evidence_id}.yaml
@@ -175,11 +175,11 @@ post:
             filename:
               type: string
             file_size:
-              type: string
+              type: integer
             file_hash:
               type: string
             type_id:
-              type: string
+              $ref: ../schemas/evidence_type_id.yaml
             start_date:
               type: string
             end_date:
@@ -194,9 +194,9 @@ post:
           example-1:
             value:
               filename: dummy file
-              file_size: '77108'
+              file_size: 77108
               file_hash: 88BC9EF6F07F0FAE922AB25EB226906542F8BA0DC1A221F3EA7273CBCB5DB0D4
-              type_id: '2'
+              type_id: 2
               start_date: '2024-04-13T03:02:00.000'
               end_date: '2024-04-04T00:00:00.000'
               custom_attributes: {}

--- a/docs/api_reference/reference/v2.1.0/resources/case_evidences_update_{evidence_id}.yaml
+++ b/docs/api_reference/reference/v2.1.0/resources/case_evidences_update_{evidence_id}.yaml
@@ -1,6 +1,8 @@
 post:
   summary: Update an evidence
   operationId: post-case-evidences-update
+  description: This endpoint is deprecated. Use [PUT /api/v2/cases/{case_identifier}/evidences/{identifier}](#tag/Evidences/operation/api_v2_cases_(case_identifier)_evidences_(identifier)_put) instead.
+  deprecated: true
   responses:
     '200':
       description: OK
@@ -144,7 +146,6 @@ post:
                   file_size: 0
                   end_date: null
                   file_description: string
-  description: 'Update an evidence. '
   parameters:
     - schema:
         type: integer

--- a/docs/api_reference/reference/v2.1.0/resources/global_tasks_update_{task_id}.yaml
+++ b/docs/api_reference/reference/v2.1.0/resources/global_tasks_update_{task_id}.yaml
@@ -50,8 +50,9 @@ post:
                   task_assignee_id:
                     type: number
                   task_close_date:
-                    type: string
-                    nullable: true
+                    type:
+                      - string
+                      - 'null'
                   task_description:
                     type: string
                     minLength: 1
@@ -72,11 +73,13 @@ post:
                     type: string
                     minLength: 1
                   task_userid_close:
-                    type: integer
-                    nullable: true
+                    type:
+                      - integer
+                      - 'null'
                   task_userid_open:
-                    type: integer
-                    nullable: true
+                    type:
+                      - integer
+                      - 'null'
                   task_userid_update:
                     type: number
               message:

--- a/docs/api_reference/reference/v2.1.0/responses/Forbidden.yaml
+++ b/docs/api_reference/reference/v2.1.0/responses/Forbidden.yaml
@@ -1,0 +1,2 @@
+description: Insufficient permissions to access resource
+

--- a/docs/api_reference/reference/v2.1.0/responses/GenericError.yaml
+++ b/docs/api_reference/reference/v2.1.0/responses/GenericError.yaml
@@ -2,7 +2,14 @@ description: Error
 content:
   application/json:
     schema:
-      description: 'Error message'
-      type: string
-      examples:
-        - 'Error processing request - check server logs'
+      type: object
+      properties:
+        message:
+          description: Error message
+          type: string
+          examples:
+            - 'Error processing request - check server logs'
+        data:
+          description: Optional additional error data
+      required:
+        - message

--- a/docs/api_reference/reference/v2.1.0/schemas/Evidence.yaml
+++ b/docs/api_reference/reference/v2.1.0/schemas/Evidence.yaml
@@ -5,9 +5,9 @@ properties:
   case_id:
     type: integer
   type_id:
-    type: 
-      - integer
-      - 'null'
+   anyOf:
+      - $ref: ../schemas/evidence_type_id.yaml
+      - type: 'null'
   id:
     type: integer
   file_hash:

--- a/docs/api_reference/reference/v2.1.0/schemas/Evidences.yaml
+++ b/docs/api_reference/reference/v2.1.0/schemas/Evidences.yaml
@@ -1,0 +1,17 @@
+type: object
+properties:
+  total:
+    type: integer
+  data:
+    type: array
+    items:
+      $ref: ../schemas/Evidence.yaml
+  last_page:
+    type: integer
+  current_page:
+    type: integer
+  next_page:
+    type:
+      - integer
+      - 'null'
+

--- a/docs/api_reference/reference/v2.1.0/schemas/evidence_type_id.yaml
+++ b/docs/api_reference/reference/v2.1.0/schemas/evidence_type_id.yaml
@@ -1,0 +1,2 @@
+type: integer
+description: Identifier of the type of an evidence. See [GET /manage/evidence-types/list](#tag/Manage-evidence-types/operation/get-evidence-types-list) for possible values.


### PR DESCRIPTION
Documentation of `PUT /api/v2/cases/{case_identifier}/evidences/{identifier}` .

* Deprecated `POST /case/evidences/update/{evidence_id}`
* Introduced schema `Forbidden.yaml` to factor documentation of permission errors
* Introduced schema `evidence_type_id.yaml` to factor documentation of evidence types
* quality: fixed some lint warnings of type `struct`

Note: this PR's branch follows branch `api_v2_get_paginated_evidence`, so it should be merged after [PR#48](https://github.com/dfir-iris/iris-doc-src/pull/48)