### PR TITLE
Api v2 delete evidence

### DIFF
--- a/docs/api_reference/reference/.redocly.lint-ignore.yaml
+++ b/docs/api_reference/reference/.redocly.lint-ignore.yaml
@@ -536,13 +536,6 @@ v2.1.0/resources/manage_cases_list.yaml:
 v2.1.0/resources/manage_cases_close_{case_id}.yaml:
   operation-4xx-response:
     - '#/post/responses'
-  struct:
-    - >-
-      #/post/responses/200/content/application~1json/schema/properties/data/properties/closing_note/nullable
-    - >-
-      #/post/responses/200/content/application~1json/schema/properties/data/properties/custom_attributes/nullable
-    - >-
-      #/post/responses/200/content/application~1json/schema/properties/data/properties/classification_id/nullable
   no-invalid-media-type-examples:
     - '#/post/responses/200/content/application~1json/schema'
 v2.1.0/resources/manage_cases_reopen_{case_id}.yaml:

--- a/docs/api_reference/reference/iris.v2.1.0.yaml
+++ b/docs/api_reference/reference/iris.v2.1.0.yaml
@@ -45,6 +45,7 @@ info:
     * Added GET /api/v2/cases/{case_identifier}/evidences
     * Added GET /api/v2/cases/{case_identifier}/evidences/{identifier}
     * Added PUT /api/v2/cases/{case_identifier}/evidences/{identifier}
+    * Added DELETE /api/v2/cases/{case_identifier}/evidences/{identifier}
     * Deprecated POST /manage/cases/add in favor of POST /api/v2/cases
     * Deprecated POST /manage/cases/update in favor of PUT /api/v2/cases/{case_identifier}
     * Deprecated POST /manage/cases/delete/{case_id} in favor of DELETE /api/v2/cases/{case_identifier}

--- a/docs/api_reference/reference/iris.v2.1.0.yaml
+++ b/docs/api_reference/reference/iris.v2.1.0.yaml
@@ -73,6 +73,7 @@ info:
     * Added documentation of missing GET /manage/tlp/list
     * Added documentation of missing GET /manage/event-categories/list
     * Added documentation of missing GET /manage/compromise-status/list
+    * Fixed: removed documentation of unimplemented endpoint GET /case/evidences/delete/{evidence_id}
 
     ### Changes in v2.0.0
     This version introduces access control. Every request now needs to have the `cid=x` parameter in the URI.  

--- a/docs/api_reference/reference/iris.v2.1.0.yaml
+++ b/docs/api_reference/reference/iris.v2.1.0.yaml
@@ -69,6 +69,7 @@ info:
     * Deprecated GET /case/evidences/list in favor of GET /api/v2/cases/{case_identifier}/evidences
     * Deprecated GET /case/evidences/{evidence_id} in favor of GET /api/v2/cases/{case_identifier}/evidences/{identifier}
     * Deprecated POST /case/evidences/udpate/{evidence_id} in favor of PUT /api/v2/cases/{case_identifier}/evidences/{identifier}
+    * Deprecated POST /case/evidences/delete/{evidence_id} in favor of DELETE /api/v2/cases/{case_identifier}/evidences/{identifier}
     * Added documentation of missing GET /manage/severities/list
     * Added documentation of missing GET /manage/tlp/list
     * Added documentation of missing GET /manage/event-categories/list

--- a/docs/api_reference/reference/v2.1.0/resources/api_v2_cases_{case_identifier}_assets_{identifier}.yaml
+++ b/docs/api_reference/reference/v2.1.0/resources/api_v2_cases_{case_identifier}_assets_{identifier}.yaml
@@ -92,6 +92,8 @@ delete:
   responses:
     '204':
       $ref: ../responses/Deleted.yaml
+    '403':
+      $ref: ../responses/Forbidden.yaml
     '404':
       $ref: ../responses/NotFound.yaml
     '400':

--- a/docs/api_reference/reference/v2.1.0/resources/api_v2_cases_{case_identifier}_assets_{identifier}.yaml
+++ b/docs/api_reference/reference/v2.1.0/resources/api_v2_cases_{case_identifier}_assets_{identifier}.yaml
@@ -87,6 +87,7 @@ delete:
   operationId: api_v2_cases_(case_identifier)_assets_(identifier)_delete
   tags:
     - Assets
+    - Beta
   summary: Delete an asset
   responses:
     '204':

--- a/docs/api_reference/reference/v2.1.0/resources/api_v2_cases_{case_identifier}_evidences_{identifier}.yaml
+++ b/docs/api_reference/reference/v2.1.0/resources/api_v2_cases_{case_identifier}_evidences_{identifier}.yaml
@@ -70,4 +70,19 @@ put:
       $ref: ../responses/NotFound.yaml
     '400':
       $ref: ../responses/GenericError.yaml
+delete:
+  operationId: api_v2_cases_(case_identifier)_evidences_(identifier)_delete
+  tags:
+    - Evidences
+    - Beta
+  summary: Delete an evidence
+  responses:
+    '204':
+      $ref: ../responses/Deleted.yaml
+    '403':
+      $ref: ../responses/Forbidden.yaml
+    '404':
+      $ref: ../responses/NotFound.yaml
+    '400':
+      $ref: ../responses/GenericError.yaml
 

--- a/docs/api_reference/reference/v2.1.0/resources/case_evidences_delete_{evidence_id}.yaml
+++ b/docs/api_reference/reference/v2.1.0/resources/case_evidences_delete_{evidence_id}.yaml
@@ -48,12 +48,3 @@ parameters:
     in: path
     required: true
     description: Evidence ID
-get:
-  summary: Delete an evidence
-  operationId: get-case-evidences-delete-evidence_id
-  responses:
-    '200':
-      description: OK
-  tags:
-    - Evidences
-  description: This endpoint is depreacted. Please use the POST equivalent.

--- a/docs/api_reference/reference/v2.1.0/resources/case_evidences_delete_{evidence_id}.yaml
+++ b/docs/api_reference/reference/v2.1.0/resources/case_evidences_delete_{evidence_id}.yaml
@@ -1,5 +1,8 @@
 post:
   summary: Delete a case evidence
+  operationId: post-case-evidences-delete
+  description: This endpoint is deprecated. Use [DELETE /api/v2/cases/{case_identifier}/evidences/{identifier}](#tag/Evidences/operation/api_v2_cases_(case_identifier)_evidences_(identifier)_delete) instead.
+  deprecated: true
   tags:
     - Evidences
   responses:
@@ -30,8 +33,6 @@ post:
                 data: []
                 message: Evidence deleted
                 status: success
-  operationId: post-case-evidences-delete
-  description: 'Remove an evidence from the case. '
   parameters:
     - schema:
         type: integer

--- a/docs/api_reference/reference/v2.1.0/resources/manage_cases_close_{case_id}.yaml
+++ b/docs/api_reference/reference/v2.1.0/resources/manage_cases_close_{case_id}.yaml
@@ -176,7 +176,9 @@ post:
                   case_name:
                     type: string
                   closing_note:
-                    nullable: true
+                    type:
+                      - string
+                      - 'null'
                   user_id:
                     type: integer
                   owner_id:
@@ -192,7 +194,9 @@ post:
                   modification_history:
                     type: object
                   custom_attributes:
-                    nullable: true
+                    type:
+                      - object
+                      - 'null'
                   close_date:
                     type: string
                   case_description:
@@ -200,7 +204,9 @@ post:
                   state_id:
                     type: integer
                   classification_id:
-                    nullable: true
+                    type:
+                      - integer
+                      - 'null'
           examples:
             Example 1:
               value:


### PR DESCRIPTION
Documentation of `DELETE /api/v2/cases/{case_identifier}/evidences/{identifier}`.

- deprecated `POST /case/evidence/delete/{evidence_id}`
- fixed some lint errors
- removed documentation of endpoint GET /case/evidences/delete/{evidence_id} (as it seems not to exist in the implementation at all)

Warning: this PR is built on a branch which follows `modification_history_for_assets`, so it should be merged after [PR#50](https://github.com/dfir-iris/iris-doc-src/pull/50)