### PR TITLE
Api v2 create event

### DIFF
--- a/docs/api_reference/reference/.redocly.lint-ignore.yaml
+++ b/docs/api_reference/reference/.redocly.lint-ignore.yaml
@@ -636,8 +636,6 @@ v2.1.0/resources/manage_case-classifications_list.yaml:
   operation-4xx-response:
     - '#/get/responses'
 v2.1.0/resources/manage_case-classifications_{classification_id}.yaml:
-  struct:
-    - '#/get/responses/'
   operation-4xx-response:
     - '#/get/responses'
   no-invalid-media-type-examples:
@@ -656,8 +654,6 @@ v2.1.0/resources/manage_case-states_list.yaml:
   operation-4xx-response:
     - '#/get/responses'
 v2.1.0/resources/manage_case-states_{state_id}.yaml:
-  struct:
-    - '#/get/responses/'
   operation-4xx-response:
     - '#/get/responses'
 v2.1.0/resources/manage_case-states_add.yaml:
@@ -679,8 +675,6 @@ v2.1.0/resources/manage_evidence-types_list.yaml:
   operation-4xx-response:
     - '#/get/responses'
 v2.1.0/resources/manage_evidence-types_{type_id}.yaml:
-  struct:
-    - '#/get/responses/'
   operation-4xx-response:
     - '#/get/responses'
 v2.1.0/resources/manage_evidence-types_add.yaml:

--- a/docs/api_reference/reference/.redocly.lint-ignore.yaml
+++ b/docs/api_reference/reference/.redocly.lint-ignore.yaml
@@ -615,20 +615,14 @@ v2.1.0/resources/manage_tlp_list.yaml:
   operation-4xx-response:
     - '#/get/responses'
 v2.1.0/resources/manage_case-templates_add.yaml:
-  struct:
-    - '#/post/responses/'
   no-invalid-media-type-examples:
     - >-
       #/post/responses/400/content/application~1json/examples/example-1/value/data
 v2.1.0/resources/manage_case-templates_update_{template_id}.yaml:
-  struct:
-    - '#/post/responses/'
   no-invalid-media-type-examples:
     - >-
       #/post/responses/400/content/application~1json/examples/example-1/value/data
 v2.1.0/resources/manage_case-templates_delete_{template_id}.yaml:
-  struct:
-    - '#/post/responses/'
   no-invalid-media-type-examples:
     - >-
       #/post/responses/400/content/application~1json/examples/example-1/value/data

--- a/docs/api_reference/reference/iris.v2.1.0.yaml
+++ b/docs/api_reference/reference/iris.v2.1.0.yaml
@@ -71,6 +71,7 @@ info:
     * Deprecated GET /case/evidences/{evidence_id} in favor of GET /api/v2/cases/{case_identifier}/evidences/{identifier}
     * Deprecated POST /case/evidences/udpate/{evidence_id} in favor of PUT /api/v2/cases/{case_identifier}/evidences/{identifier}
     * Deprecated POST /case/evidences/delete/{evidence_id} in favor of DELETE /api/v2/cases/{case_identifier}/evidences/{identifier}
+    * Deprecated POST /case/timeline/events/add in favor of POST /api/v2/cases/{case_identifier}/events
     * Added documentation of missing GET /manage/severities/list
     * Added documentation of missing GET /manage/tlp/list
     * Added documentation of missing GET /manage/event-categories/list

--- a/docs/api_reference/reference/iris.v2.1.0.yaml
+++ b/docs/api_reference/reference/iris.v2.1.0.yaml
@@ -46,6 +46,7 @@ info:
     * Added GET /api/v2/cases/{case_identifier}/evidences/{identifier}
     * Added PUT /api/v2/cases/{case_identifier}/evidences/{identifier}
     * Added DELETE /api/v2/cases/{case_identifier}/evidences/{identifier}
+    * Added POST /api/v2/cases/{case_identifier}/events
     * Deprecated POST /manage/cases/add in favor of POST /api/v2/cases
     * Deprecated POST /manage/cases/update in favor of PUT /api/v2/cases/{case_identifier}
     * Deprecated POST /manage/cases/delete/{case_id} in favor of DELETE /api/v2/cases/{case_identifier}
@@ -120,6 +121,8 @@ paths:
     $ref: v2.1.0/resources/api_v2_cases_{case_identifier}_evidences.yaml
   /api/v2/cases/{case_identifier}/evidences/{identifier}:
     $ref: v2.1.0/resources/api_v2_cases_{case_identifier}_evidences_{identifier}.yaml
+  /api/v2/cases/{case_identifier}/events:
+    $ref: v2.1.0/resources/api_v2_cases_{case_identifier}_events.yaml
   /manage/cases/update/{case_id}:
     $ref: v2.1.0/resources/manage_cases_update_{case_id}.yaml
   /api/v2/iocs/{identifier}:

--- a/docs/api_reference/reference/redocly.yaml
+++ b/docs/api_reference/reference/redocly.yaml
@@ -1,0 +1,2 @@
+extends:
+  - recommended-strict

--- a/docs/api_reference/reference/v2.1.0/resources/api_v2_cases_{case_identifier}_events.yaml
+++ b/docs/api_reference/reference/v2.1.0/resources/api_v2_cases_{case_identifier}_events.yaml
@@ -85,6 +85,8 @@ post:
             $ref: ../schemas/Event.yaml
     '400':
       $ref: ../responses/GenericError.yaml
+    '403':
+      $ref: ../responses/Forbidden.yaml
     '404':
       description: Case with identifier case_identifier not found
 

--- a/docs/api_reference/reference/v2.1.0/resources/api_v2_cases_{case_identifier}_events.yaml
+++ b/docs/api_reference/reference/v2.1.0/resources/api_v2_cases_{case_identifier}_events.yaml
@@ -15,9 +15,11 @@ post:
           properties:
             event_title:
               type: string
-            event_raw:
+            event_category_id:
+              type: integer
+            event_date:
               type: string
-            event_source:
+            event_tz:
               type: string
             event_assets:
               type: array
@@ -27,7 +29,9 @@ post:
               type: array
               items:
                 type: integer
-            event_category_id:
+            event_raw:
+              type: string
+            event_source:
               type: string
             event_in_summary:
               type: boolean
@@ -35,13 +39,9 @@ post:
               type: boolean
             event_color:
               type: string
-            event_date:
-              type: string
             event_sync_iocs_assets:
               type: boolean
             event_tags:
-              type: string
-            event_tz:
               type: string
             event_content:
               type: string
@@ -51,29 +51,31 @@ post:
               type: integer
           required:
             - event_title
+            - event_category_id
             - event_date
             - event_tz
-        examples:
-          example-1:
-            value:
-              event_title: An event
-              event_raw: My event raw data
-              event_source: My source
-              event_assets:
-                - 45
-              event_iocs:
-                - 33
-              event_category_id: '5'
-              event_in_summary: true
-              event_in_graph: true
-              event_color: '#1572E899'
-              event_date: '2023-03-08T03:02:00.000'
-              event_sync_iocs_assets: true
-              event_tags: tag
-              event_tz: '+00:00'
-              event_content: My description
-              parent_event_id: 11
-              custom_attributes: {}
+            - event_assets
+            - event_iocs
+        example:
+          value:
+            event_title: An event
+            event_category_id: 5
+            event_date: '2023-03-08T03:02:00.000'
+            event_tz: '+00:00'
+            event_assets:
+              - 45
+            event_iocs:
+              - 33
+            event_raw: My event raw data
+            event_source: My source
+            event_in_summary: true
+            event_in_graph: true
+            event_color: '#1572E899'
+            event_sync_iocs_assets: true
+            event_tags: tag
+            event_content: My description
+            parent_event_id: 11
+            custom_attributes: {}
   responses:
     '201':
       description: Evidence successfully created

--- a/docs/api_reference/reference/v2.1.0/resources/api_v2_cases_{case_identifier}_events.yaml
+++ b/docs/api_reference/reference/v2.1.0/resources/api_v2_cases_{case_identifier}_events.yaml
@@ -57,25 +57,24 @@ post:
             - event_assets
             - event_iocs
         example:
-          value:
-            event_title: An event
-            event_category_id: 5
-            event_date: '2023-03-08T03:02:00.000'
-            event_tz: '+00:00'
-            event_assets:
-              - 45
-            event_iocs:
-              - 33
-            event_raw: My event raw data
-            event_source: My source
-            event_in_summary: true
-            event_in_graph: true
-            event_color: '#1572E899'
-            event_sync_iocs_assets: true
-            event_tags: tag
-            event_content: My description
-            parent_event_id: 11
-            custom_attributes: {}
+          event_title: An event
+          event_category_id: 5
+          event_date: '2023-03-08T03:02:00.000'
+          event_tz: '+00:00'
+          event_assets:
+            - 45
+          event_iocs:
+            - 33
+          event_raw: My event raw data
+          event_source: My source
+          event_in_summary: true
+          event_in_graph: true
+          event_color: '#1572E899'
+          event_sync_iocs_assets: true
+          event_tags: tag
+          event_content: My description
+          parent_event_id: 11
+          custom_attributes: {}
   responses:
     '201':
       description: Evidence successfully created

--- a/docs/api_reference/reference/v2.1.0/resources/api_v2_cases_{case_identifier}_events.yaml
+++ b/docs/api_reference/reference/v2.1.0/resources/api_v2_cases_{case_identifier}_events.yaml
@@ -1,0 +1,88 @@
+parameters:
+  - $ref: ../parameters/path/case_identifier.yaml
+post:
+  operationId: api_v2_cases_(case_identifier)_events_post
+  summary: Add a new event
+  description: Create a new event in the timeline.
+  tags:
+    - Timeline
+    - Beta
+  requestBody:
+    content:
+      application/json:
+        schema:
+          type: object
+          properties:
+            event_title:
+              type: string
+            event_raw:
+              type: string
+            event_source:
+              type: string
+            event_assets:
+              type: array
+              items:
+                type: integer
+            event_iocs:
+              type: array
+              items:
+                type: integer
+            event_category_id:
+              type: string
+            event_in_summary:
+              type: boolean
+            event_in_graph:
+              type: boolean
+            event_color:
+              type: string
+            event_date:
+              type: string
+            event_sync_iocs_assets:
+              type: boolean
+            event_tags:
+              type: string
+            event_tz:
+              type: string
+            event_content:
+              type: string
+            custom_attributes:
+              type: object
+            parent_event_id:
+              type: integer
+          required:
+            - event_title
+            - event_date
+            - event_tz
+        examples:
+          example-1:
+            value:
+              event_title: An event
+              event_raw: My event raw data
+              event_source: My source
+              event_assets:
+                - 45
+              event_iocs:
+                - 33
+              event_category_id: '5'
+              event_in_summary: true
+              event_in_graph: true
+              event_color: '#1572E899'
+              event_date: '2023-03-08T03:02:00.000'
+              event_sync_iocs_assets: true
+              event_tags: tag
+              event_tz: '+00:00'
+              event_content: My description
+              parent_event_id: 11
+              custom_attributes: {}
+  responses:
+    '201':
+      description: Evidence successfully created
+      content:
+        application/json:
+          schema:
+            $ref: ../schemas/Event.yaml
+    '400':
+      $ref: ../responses/GenericError.yaml
+    '404':
+      description: Case with identifier case_identifier not found
+

--- a/docs/api_reference/reference/v2.1.0/resources/api_v2_cases_{case_identifier}_evidences.yaml
+++ b/docs/api_reference/reference/v2.1.0/resources/api_v2_cases_{case_identifier}_evidences.yaml
@@ -48,6 +48,8 @@ post:
             $ref: ../schemas/Evidence.yaml
     '400':
       $ref: ../responses/GenericError.yaml
+    '403':
+      $ref: ../responses/Forbidden.yaml
     '404':
       description: Case with identifier case_identifier not found
 get:

--- a/docs/api_reference/reference/v2.1.0/resources/api_v2_iocs_{identifier}.yaml
+++ b/docs/api_reference/reference/v2.1.0/resources/api_v2_iocs_{identifier}.yaml
@@ -48,14 +48,12 @@ put:
             ioc_tags:
               type: string
               description : 'Ioc tags'
-        examples:
-           Valid request:
-             value:
-               ioc_value: 8.8.8.8
-               ioc_type_id: 1
-               ioc_tlp_id: 2
-               ioc_description: rewrw
-               ioc_tags: ''
+        example:
+          ioc_value: 8.8.8.8
+          ioc_type_id: 1
+          ioc_tlp_id: 2
+          ioc_description: rewrw
+          ioc_tags: ''
   responses:
     '200':
       description: IOC successfully updated

--- a/docs/api_reference/reference/v2.1.0/resources/case_timeline_events_add.yaml
+++ b/docs/api_reference/reference/v2.1.0/resources/case_timeline_events_add.yaml
@@ -2,6 +2,8 @@ parameters: []
 post:
   summary: Add a new event
   operationId: post-case-timeline-add-delete-event_id---copy
+  description: This endpoint is deprecated. Use [POST /api/v2/cases/{case_identifier}/events](#tag/Timeline/operation/api_v2_cases_(case_identifier)_events_post) instead.
+  deprecated: true
   responses:
     '200':
       description: OK
@@ -142,7 +144,6 @@ post:
                   event_raw: My event raw data
                   event_date_wtz: '2023-03-08T03:02:00.000000'
                   event_id: 663
-  description: 'Create a new event in the timeline. '
   requestBody:
     content:
       application/json:

--- a/docs/api_reference/reference/v2.1.0/resources/manage_case-classifications_{classification_id}.yaml
+++ b/docs/api_reference/reference/v2.1.0/resources/manage_case-classifications_{classification_id}.yaml
@@ -338,8 +338,6 @@ get:
                   name_expanded: 'Abusive-Content: spam'
                   id: 1
                   name: abusive-content:spam
-    '':
-      description: ''
   operationId: get-case-classifications-detail
   description: 'Get a case classification from an ID. '
   tags:

--- a/docs/api_reference/reference/v2.1.0/resources/manage_case-states_{state_id}.yaml
+++ b/docs/api_reference/reference/v2.1.0/resources/manage_case-states_{state_id}.yaml
@@ -43,8 +43,6 @@ get:
                   state_description: Unspecified
                   state_id: 1
                   protected: true
-    '':
-      description: ''
   operationId: get-case-states-detail
   description: 'Get a case state from an ID. '
   tags:

--- a/docs/api_reference/reference/v2.1.0/resources/manage_case-templates_add.yaml
+++ b/docs/api_reference/reference/v2.1.0/resources/manage_case-templates_add.yaml
@@ -89,43 +89,6 @@ post:
                 data: []
                 message: Invalid ioc type ID 1700
                 status: error
-    '':
-      description: ''
-      content:
-        application/json:
-          schema:
-            type: object
-            properties:
-              status:
-                type: string
-              message:
-                type: string
-              data:
-                type: object
-                properties:
-                  case_template_id:
-                    type: integer
-                  case_template_name:
-                    type: string
-                  case_template_description:
-                    type: string
-            x-examples:
-              Example 1:
-                status: success
-                message: Added successfully
-                data:
-                  case_template_id: 4
-                  case_template_name: Template name
-                  case_template_description: Template description
-          examples:
-            Example 1:
-              value:
-                status: success
-                message: Added successfully
-                data:
-                  case_template_id: 4
-                  case_template_name: Template name
-                  case_template_description: Template description
   description: 'Add a new case template. '
   requestBody:
     content:

--- a/docs/api_reference/reference/v2.1.0/resources/manage_case-templates_delete_{template_id}.yaml
+++ b/docs/api_reference/reference/v2.1.0/resources/manage_case-templates_delete_{template_id}.yaml
@@ -95,33 +95,6 @@ post:
                 data: []
                 message: Invalid ioc type ID 1700
                 status: error
-    '':
-      description: ''
-      content:
-        application/json:
-          schema:
-            type: object
-            properties:
-              status:
-                type: string
-              message:
-                type: string
-              data:
-                type: array
-                items:
-                  type: object
-                  properties: {}
-            x-examples:
-              Example 1:
-                status: success
-                message: Deleted successfully
-                data: []
-          examples:
-            Example 1:
-              value:
-                status: success
-                message: Deleted successfully
-                data: []
   description: 'Delete a case template. '
   tags:
     - Manage Cases Templates

--- a/docs/api_reference/reference/v2.1.0/resources/manage_case-templates_update_{template_id}.yaml
+++ b/docs/api_reference/reference/v2.1.0/resources/manage_case-templates_update_{template_id}.yaml
@@ -95,33 +95,6 @@ post:
                 data: []
                 message: Invalid ioc type ID 1700
                 status: error
-    '':
-      description: ''
-      content:
-        application/json:
-          schema:
-            type: object
-            properties:
-              status:
-                type: string
-              message:
-                type: string
-              data:
-                type: array
-                items:
-                  type: object
-                  properties: {}
-            x-examples:
-              Example 1:
-                status: success
-                message: Case template updated
-                data: []
-          examples:
-            Example 1:
-              value:
-                status: success
-                message: Case template updated
-                data: []
   description: 'Update a case template. '
   requestBody:
     content:

--- a/docs/api_reference/reference/v2.1.0/resources/manage_evidence-types_{type_id}.yaml
+++ b/docs/api_reference/reference/v2.1.0/resources/manage_evidence-types_{type_id}.yaml
@@ -43,47 +43,6 @@ get:
                   state_description: Unspecified
                   state_id: 1
                   protected: true
-    '':
-      description: ''
-      content:
-        application/json:
-          schema:
-            type: object
-            properties:
-              status:
-                type: string
-              message:
-                type: string
-              data:
-                type: object
-                properties:
-                  name:
-                    type: string
-                  description:
-                    type: string
-                  id:
-                    type: integer
-                  creation_date:
-                    type: string
-            x-examples:
-              Example 1:
-                status: success
-                message: ''
-                data:
-                  name: Unspecified
-                  description: Unspecified
-                  id: 1
-                  creation_date: '2023-11-29T10:28:30.448583'
-          examples:
-            Example 1:
-              value:
-                status: success
-                message: ''
-                data:
-                  name: Unspecified
-                  description: Unspecified
-                  id: 1
-                  creation_date: '2023-11-29T10:28:30.448583'
   operationId: get-evidence-types-detail
   description: 'Get a evidence type from an ID. '
   tags:

--- a/docs/api_reference/reference/v2.1.0/schemas/Event.yaml
+++ b/docs/api_reference/reference/v2.1.0/schemas/Event.yaml
@@ -1,0 +1,75 @@
+type: object
+properties:
+  event_tags:
+    type: string
+  case_id:
+    type: integer
+  event_in_summary:
+    type: boolean
+  modification_history:
+    type: object
+  event_date:
+    type: string
+  event_title:
+    type: string
+  custom_attributes:
+    type: object
+  user_id:
+    type: integer
+  event_color:
+    type: string
+  event_added:
+    type: string
+  event_in_graph:
+    type: boolean
+  event_tz:
+    type: string
+  event_content:
+    type: string
+  event_source:
+    type: string
+  event_category_id:
+    type: integer
+  event_uuid:
+    type: string
+  event_is_flagged:
+    type: boolean
+  event_raw:
+    type: string
+  event_date_wtz:
+    type: string
+  event_id:
+    type: integer
+  parent_event_id:
+    type:
+      - integer
+      - 'null'
+example:
+  status: success
+  message: Event added
+  data:
+  event_tags: tag
+  case_id: 1
+  event_in_summary: true
+  modification_history:
+    '1704815112.677327':
+      user: administrator
+      action: created
+      user_id: 1
+  event_date: '2023-03-08T03:02:00.000000'
+  event_title: An event
+  custom_attributes: {}
+  user_id: 1
+  event_color: '#1572E899'
+  event_added: '2024-01-09T15:45:12.677273'
+  event_in_graph: true
+  event_tz: '+00:00'
+  event_content: My description
+  event_source: My source
+  event_category_id: 5
+  event_uuid: f20fee77-4d9f-446d-927d-59765aa9cbe0
+  event_is_flagged: false
+  event_raw: My event raw data
+  event_date_wtz: '2023-03-08T03:02:00.000000'
+  event_id: 663
+  parent_event_id: null

--- a/docs/api_reference/reference/v2.1.0/schemas/Event.yaml
+++ b/docs/api_reference/reference/v2.1.0/schemas/Event.yaml
@@ -1,75 +1,90 @@
 type: object
 properties:
-  event_tags:
-    type: string
-  case_id:
-    type: integer
-  event_in_summary:
-    type: boolean
-  modification_history:
-    type: object
-  event_date:
-    type: string
-  event_title:
-    type: string
-  custom_attributes:
-    type: object
-  user_id:
-    type: integer
-  event_color:
-    type: string
-  event_added:
-    type: string
-  event_in_graph:
-    type: boolean
-  event_tz:
-    type: string
-  event_content:
-    type: string
-  event_source:
-    type: string
-  event_category_id:
+  event_id:
     type: integer
   event_uuid:
     type: string
-  event_is_flagged:
-    type: boolean
-  event_raw:
-    type: string
-  event_date_wtz:
-    type: string
-  event_id:
+  case_id:
+    type: integer
+  user_id:
     type: integer
   parent_event_id:
     type:
       - integer
       - 'null'
+  event_title:
+    type: string
+  event_category_id:
+    type: integer
+  event_content:
+    type:
+      - string
+      - 'null'
+  event_color:
+    type:
+      - string
+      - 'null'
+  event_source:
+    type:
+      - string
+      - 'null'
+  event_raw:
+    type:
+      - string
+      - 'null'
+  event_tags:
+    type:
+      - string
+      - 'null'
+  event_date:
+    type: string
+  event_tz:
+    type: string
+  event_date_wtz:
+    type: string
+  event_added:
+    type: string
+  event_in_summary:
+    type:
+      - boolean
+      - 'null'
+  event_in_graph:
+    type:
+      - boolean
+      - 'null'
+  event_is_flagged:
+    type: boolean
+  modification_history:
+    anyOf:
+      - $ref: ../schemas/modification_history.yaml
+      - type: 'null'
+  custom_attributes:
+    type:
+      - object
+      - 'null'
 example:
-  status: success
-  message: Event added
-  data:
-  event_tags: tag
+  event_id: 663
+  event_uuid: f20fee77-4d9f-446d-927d-59765aa9cbe0
   case_id: 1
+  user_id: 1
+  parent_event_id: null
+  event_title: An event
+  event_category_id: 5
+  event_content: My description
+  event_color: '#1572E899'
+  event_source: My source
+  event_raw: My event raw data
+  event_tags: tag
+  event_date: '2023-03-08T03:02:00.000000'
+  event_tz: '+00:00'
+  event_date_wtz: '2023-03-08T03:02:00.000000'
+  event_added: '2024-01-09T15:45:12.677273'
   event_in_summary: true
+  event_in_graph: true
+  event_is_flagged: false
   modification_history:
     '1704815112.677327':
       user: administrator
       action: created
       user_id: 1
-  event_date: '2023-03-08T03:02:00.000000'
-  event_title: An event
   custom_attributes: {}
-  user_id: 1
-  event_color: '#1572E899'
-  event_added: '2024-01-09T15:45:12.677273'
-  event_in_graph: true
-  event_tz: '+00:00'
-  event_content: My description
-  event_source: My source
-  event_category_id: 5
-  event_uuid: f20fee77-4d9f-446d-927d-59765aa9cbe0
-  event_is_flagged: false
-  event_raw: My event raw data
-  event_date_wtz: '2023-03-08T03:02:00.000000'
-  event_id: 663
-  parent_event_id: null


### PR DESCRIPTION
Documentation of `POST /api/v2/cases/{case_identifier}/events`.

- deprecated `POST /case/timeline/events/add`
- fixed some lint errors
- added a missing 403
