### PR TITLE
Api v2 get event

### DIFF
--- a/docs/api_reference/reference/.redocly.lint-ignore.yaml
+++ b/docs/api_reference/reference/.redocly.lint-ignore.yaml
@@ -471,9 +471,6 @@ v2.1.0/resources/datastore_file_view_{file_id}.yaml:
 v2.1.0/resources/datastore_file_move_{file_id}.yaml:
   operation-4xx-response:
     - '#/post/responses'
-  struct:
-    - >-
-      #/post/responses/200/content/application~1json/schema/properties/data/items/nullable
 v2.1.0/resources/datastore_folder_add.yaml:
   operation-4xx-response:
     - '#/post/responses'

--- a/docs/api_reference/reference/.redocly.lint-ignore.yaml
+++ b/docs/api_reference/reference/.redocly.lint-ignore.yaml
@@ -518,11 +518,6 @@ v2.1.0/resources/global_tasks_list.yaml:
   operation-4xx-response:
     - '#/get/responses'
 v2.1.0/resources/global_tasks_add.yaml:
-  struct:
-    - >-
-      #/post/responses/200/content/application~1json/schema/properties/data/properties/task_close_date/nullable
-    - >-
-      #/post/responses/200/content/application~1json/schema/properties/data/properties/task_userid_close/nullable
   no-invalid-media-type-examples:
     - >-
       #/post/responses/200/content/application~1json/examples/Success/value/data/task_userid_open

--- a/docs/api_reference/reference/.redocly.lint-ignore.yaml
+++ b/docs/api_reference/reference/.redocly.lint-ignore.yaml
@@ -477,10 +477,6 @@ v2.1.0/resources/datastore_file_move_{file_id}.yaml:
 v2.1.0/resources/datastore_folder_add.yaml:
   operation-4xx-response:
     - '#/post/responses'
-v2.1.0/resources/datastore_folder_delete_{folder_id}.yaml:
-  struct:
-    - >-
-      #/post/responses/200/content/application~1json/schema/properties/data/items/nullable
 v2.1.0/resources/datastore_folder_rename_{folder_id}.yaml:
   operation-4xx-response:
     - '#/post/responses'

--- a/docs/api_reference/reference/iris.v2.1.0.yaml
+++ b/docs/api_reference/reference/iris.v2.1.0.yaml
@@ -47,6 +47,7 @@ info:
     * Added PUT /api/v2/cases/{case_identifier}/evidences/{identifier}
     * Added DELETE /api/v2/cases/{case_identifier}/evidences/{identifier}
     * Added POST /api/v2/cases/{case_identifier}/events
+    * Added GET /api/v2/cases/{case_identifier}/events/{identifier}
     * Deprecated POST /manage/cases/add in favor of POST /api/v2/cases
     * Deprecated POST /manage/cases/update in favor of PUT /api/v2/cases/{case_identifier}
     * Deprecated POST /manage/cases/delete/{case_id} in favor of DELETE /api/v2/cases/{case_identifier}
@@ -124,6 +125,8 @@ paths:
     $ref: v2.1.0/resources/api_v2_cases_{case_identifier}_evidences_{identifier}.yaml
   /api/v2/cases/{case_identifier}/events:
     $ref: v2.1.0/resources/api_v2_cases_{case_identifier}_events.yaml
+  /api/v2/cases/{case_identifier}/events/{identifier}:
+    $ref: v2.1.0/resources/api_v2_cases_{case_identifier}_events_{identifier}.yaml
   /manage/cases/update/{case_id}:
     $ref: v2.1.0/resources/manage_cases_update_{case_id}.yaml
   /api/v2/iocs/{identifier}:

--- a/docs/api_reference/reference/iris.v2.1.0.yaml
+++ b/docs/api_reference/reference/iris.v2.1.0.yaml
@@ -73,6 +73,7 @@ info:
     * Deprecated POST /case/evidences/udpate/{evidence_id} in favor of PUT /api/v2/cases/{case_identifier}/evidences/{identifier}
     * Deprecated POST /case/evidences/delete/{evidence_id} in favor of DELETE /api/v2/cases/{case_identifier}/evidences/{identifier}
     * Deprecated POST /case/timeline/events/add in favor of POST /api/v2/cases/{case_identifier}/events
+    * Deprecated GET /case/timeline/events/{event_id} in favor of GET /api/v2/cases/{case_identifier}/events/{identifier}
     * Added documentation of missing GET /manage/severities/list
     * Added documentation of missing GET /manage/tlp/list
     * Added documentation of missing GET /manage/event-categories/list

--- a/docs/api_reference/reference/v2.1.0/resources/api_v2_cases_{case_identifier}_events_{identifier}.yaml
+++ b/docs/api_reference/reference/v2.1.0/resources/api_v2_cases_{case_identifier}_events_{identifier}.yaml
@@ -1,0 +1,24 @@
+parameters:
+  - $ref: ../parameters/path/case_identifier.yaml
+  - $ref: ../parameters/path/identifier.yaml
+get:
+  operationId: api_v2_cases_(case_identifier)_events_(identifier)_get
+  tags:
+    - Timeline
+    - Beta
+  summary: Get an event
+  description: Return information of an event of the timeline
+  responses:
+    '201':
+      description: event successfully found
+      content:
+        application/json:
+          schema:
+            $ref: ../schemas/Event.yaml
+    '400':
+      $ref: ../responses/GenericError.yaml
+    '403':
+      $ref: ../responses/Forbidden.yaml
+    '404':
+      $ref: ../responses/NotFound.yaml
+

--- a/docs/api_reference/reference/v2.1.0/resources/case_timeline_events_{event_id}.yaml
+++ b/docs/api_reference/reference/v2.1.0/resources/case_timeline_events_{event_id}.yaml
@@ -1,5 +1,7 @@
 get:
   summary: Fetch an event
+  description: This endpoint is deprecated. Use [GET /api/v2/cases/{case_identifier}/events/{identifier}](#tag/Timeline/operation/api_v2_cases_(case_identifier)_events_(identifier)_get) instead.
+  deprecated: true
   tags:
     - Timeline
   responses:
@@ -213,7 +215,6 @@ get:
                 message: Invalid event ID for this case
                 status: error
   operationId: get-case-timeline-get-event
-  description: Return information of an event of the timeline
   parameters:
     - schema:
         type: integer

--- a/docs/api_reference/reference/v2.1.0/resources/datastore_file_move_{file_id}.yaml
+++ b/docs/api_reference/reference/v2.1.0/resources/datastore_file_move_{file_id}.yaml
@@ -25,7 +25,7 @@ post:
                 type: array
                 items:
                   type: object
-                  nullable: true
+                maxItems: 0
               message:
                 type: string
               status:

--- a/docs/api_reference/reference/v2.1.0/resources/datastore_folder_delete_{folder_id}.yaml
+++ b/docs/api_reference/reference/v2.1.0/resources/datastore_folder_delete_{folder_id}.yaml
@@ -27,7 +27,7 @@ post:
                 type: array
                 items:
                   type: object
-                  nullable: true
+                maxItems: 0
               message:
                 type: string
               status:

--- a/docs/api_reference/reference/v2.1.0/resources/global_tasks_add.yaml
+++ b/docs/api_reference/reference/v2.1.0/resources/global_tasks_add.yaml
@@ -43,8 +43,9 @@ post:
                   task_assignee_id:
                     type: number
                   task_close_date:
-                    type: integer
-                    nullable: true
+                    type:
+                      - integer
+                      - 'null'
                   task_description:
                     type: string
                     minLength: 1
@@ -64,8 +65,9 @@ post:
                     type: string
                     minLength: 1
                   task_userid_close:
-                    type: integer
-                    nullable: true
+                    type:
+                      - integer
+                      - 'null'
                   task_userid_open:
                     type: integer
                   task_userid_update:

--- a/docs/api_reference/reference/v2.1.0/schemas/Event.yaml
+++ b/docs/api_reference/reference/v2.1.0/schemas/Event.yaml
@@ -56,8 +56,12 @@ properties:
     type: boolean
   modification_history:
     anyOf:
-      - $ref: ../schemas/modification_history.yaml
+      - $ref: modification_history.yaml
       - type: 'null'
+  children:
+    type: array
+    items:
+      $ref: Event.yaml
   custom_attributes:
     type:
       - object
@@ -87,4 +91,5 @@ example:
       user: administrator
       action: created
       user_id: 1
+  children: []
   custom_attributes: {}


### PR DESCRIPTION
Documentation of endpoint `GET /api/v2/cases/{case_identifier}/events/{identifier}` .

* Deprecated `GET /case/timeline/events/{event_id}`
* Documented field `children` of schema `Event`
* Fixed some lint warnings