### PR TITLE
V2 api get alert

### DIFF
--- a/docs/api_reference/reference/iris.v2.1.0.yaml
+++ b/docs/api_reference/reference/iris.v2.1.0.yaml
@@ -81,6 +81,7 @@ info:
     * Deprecated POST /case/timeline/events/update/{event_id} in favor of PUT /api/v2/cases/{case_identifier}/events/{identifier}
     * Deprecated POST /case/timeline/events/delete/{event_id} in favor of DELETE /api/v2/cases/{case_identifier}/events/{identifier}
     * Deprecated POST /alerts/add in favor of POST /api/v2/alerts
+    * Deprecated GET /alerts/{alert_id} in favor of GET /api/v2/alerts/{identifier}
     * Added documentation of missing GET /manage/severities/list
     * Added documentation of missing GET /manage/tlp/list
     * Added documentation of missing GET /manage/event-categories/list

--- a/docs/api_reference/reference/iris.v2.1.0.yaml
+++ b/docs/api_reference/reference/iris.v2.1.0.yaml
@@ -51,6 +51,7 @@ info:
     * Added PUT /api/v2/cases/{case_identifier}/events/{identifier}
     * Added DELETE /api/v2/cases/{case_identifier}/events/{identifier}
     * Added POST /api/v2/alerts
+    * Added GET /api/v2/alerts/{identifier}
     * Deprecated POST /manage/cases/add in favor of POST /api/v2/cases
     * Deprecated POST /manage/cases/update in favor of PUT /api/v2/cases/{case_identifier}
     * Deprecated POST /manage/cases/delete/{case_id} in favor of DELETE /api/v2/cases/{case_identifier}
@@ -136,6 +137,8 @@ paths:
     $ref: v2.1.0/resources/api_v2_cases_{case_identifier}_events_{identifier}.yaml
   /api/v2/alerts:
     $ref: v2.1.0/resources/api_v2_alerts.yaml
+  /api/v2/alerts/{identifier}:
+    $ref: v2.1.0/resources/api_v2_alerts_{identifier}.yaml    
   /manage/cases/update/{case_id}:
     $ref: v2.1.0/resources/manage_cases_update_{case_id}.yaml
   /api/v2/iocs/{identifier}:

--- a/docs/api_reference/reference/v2.1.0/resources/alerts_{alert_id}.yaml
+++ b/docs/api_reference/reference/v2.1.0/resources/alerts_{alert_id}.yaml
@@ -7,6 +7,8 @@ parameters:
     description: Alert ID
 get:
   summary: Fetch an alert
+  description: This endpoint is deprecated. Use [GET /api/v2/alerts/{identifier}](#tag/Alerts/operation/api_v2_alerts_(identifier)_get) instead.
+  deprecated: true
   operationId: get-alerts-get
   responses:
     '200':
@@ -1343,6 +1345,5 @@ get:
                         type: array
                         items:
                           type: integer
-  description: Fetch an alert
   tags:
     - Alerts

--- a/docs/api_reference/reference/v2.1.0/resources/api_v2_alerts_{identifier}.yaml
+++ b/docs/api_reference/reference/v2.1.0/resources/api_v2_alerts_{identifier}.yaml
@@ -1,0 +1,22 @@
+parameters:
+  - $ref: ../parameters/path/identifier.yaml
+get:
+  operationId: api_v2_alerts_(identifier)_get
+  tags: 
+    - Alerts
+    - Beta
+  summary: Get an alert
+  description: Get an alert   
+  responses:
+    '201':
+      description: Alert successfully found
+      content:
+        application/json:
+          schema:
+            $ref: ../schemas/Alert.yaml
+    '400':
+      $ref: ../responses/GenericError.yaml
+    '403':
+      $ref: ../responses/Forbidden.yaml
+    '404':
+      $ref: ../responses/NotFound.yaml


### PR DESCRIPTION
Documentation of endpoint `GET /api/v2/alerts/{identifier}`.

* Deprecated `GET /alerts/{alert_id}`