### PR TITLE
Api v2 create group

### DIFF
--- a/docs/api_reference/reference/.redocly.lint-ignore.yaml
+++ b/docs/api_reference/reference/.redocly.lint-ignore.yaml
@@ -306,8 +306,6 @@ v2.1.0/resources/alerts_add.yaml:
       #/post/responses/200/content/application~1json/schema/properties/data/properties/iocs/items/properties/ioc_misp/nullable
     - >-
       #/post/responses/200/content/application~1json/schema/properties/data/properties/iocs/items/properties/custom_attributes/nullable
-    - >-
-      #/post/responses/200/content/application~1json/schema/properties/data/properties/iocs/items/properties/ioc_type/properties/type_validation_regex/nullable
   operation-4xx-response:
     - '#/post/responses'
   no-invalid-media-type-examples:

--- a/docs/api_reference/reference/iris.v2.1.0.yaml
+++ b/docs/api_reference/reference/iris.v2.1.0.yaml
@@ -52,6 +52,7 @@ info:
     * Added DELETE /api/v2/cases/{case_identifier}/events/{identifier}
     * Added POST /api/v2/alerts
     * Added GET /api/v2/alerts/{identifier}
+    * Added POST /api/v2/groups
     * Deprecated POST /manage/cases/add in favor of POST /api/v2/cases
     * Deprecated POST /manage/cases/update in favor of PUT /api/v2/cases/{case_identifier}
     * Deprecated POST /manage/cases/delete/{case_id} in favor of DELETE /api/v2/cases/{case_identifier}
@@ -140,6 +141,8 @@ paths:
     $ref: v2.1.0/resources/api_v2_alerts.yaml
   /api/v2/alerts/{identifier}:
     $ref: v2.1.0/resources/api_v2_alerts_{identifier}.yaml    
+  /api/v2/groups:
+    $ref: v2.1.0/resources/api_v2_groups.yaml
   /manage/cases/update/{case_id}:
     $ref: v2.1.0/resources/manage_cases_update_{case_id}.yaml
   /api/v2/iocs/{identifier}:

--- a/docs/api_reference/reference/iris.v2.1.0.yaml
+++ b/docs/api_reference/reference/iris.v2.1.0.yaml
@@ -52,7 +52,7 @@ info:
     * Added DELETE /api/v2/cases/{case_identifier}/events/{identifier}
     * Added POST /api/v2/alerts
     * Added GET /api/v2/alerts/{identifier}
-    * Added POST /api/v2/groups
+    * Added POST /api/v2/manage/groups
     * Deprecated POST /manage/cases/add in favor of POST /api/v2/cases
     * Deprecated POST /manage/cases/update in favor of PUT /api/v2/cases/{case_identifier}
     * Deprecated POST /manage/cases/delete/{case_id} in favor of DELETE /api/v2/cases/{case_identifier}
@@ -141,8 +141,8 @@ paths:
     $ref: v2.1.0/resources/api_v2_alerts.yaml
   /api/v2/alerts/{identifier}:
     $ref: v2.1.0/resources/api_v2_alerts_{identifier}.yaml    
-  /api/v2/groups:
-    $ref: v2.1.0/resources/api_v2_groups.yaml
+  /api/v2/manage/groups:
+    $ref: v2.1.0/resources/api_v2_manage_groups.yaml
   /manage/cases/update/{case_id}:
     $ref: v2.1.0/resources/manage_cases_update_{case_id}.yaml
   /api/v2/iocs/{identifier}:

--- a/docs/api_reference/reference/iris.v2.1.0.yaml
+++ b/docs/api_reference/reference/iris.v2.1.0.yaml
@@ -81,6 +81,7 @@ info:
     * Deprecated POST /case/timeline/events/update/{event_id} in favor of PUT /api/v2/cases/{case_identifier}/events/{identifier}
     * Deprecated POST /case/timeline/events/delete/{event_id} in favor of DELETE /api/v2/cases/{case_identifier}/events/{identifier}
     * Deprecated POST /alerts/add in favor of POST /api/v2/alerts
+    * Deprecated GET /alerts/{alert_id} in favor of GET /api/v2/alerts/{identifier}
     * Added documentation of missing GET /manage/severities/list
     * Added documentation of missing GET /manage/tlp/list
     * Added documentation of missing GET /manage/event-categories/list

--- a/docs/api_reference/reference/iris.v2.1.0.yaml
+++ b/docs/api_reference/reference/iris.v2.1.0.yaml
@@ -83,6 +83,7 @@ info:
     * Deprecated POST /case/timeline/events/delete/{event_id} in favor of DELETE /api/v2/cases/{case_identifier}/events/{identifier}
     * Deprecated POST /alerts/add in favor of POST /api/v2/alerts
     * Deprecated GET /alerts/{alert_id} in favor of GET /api/v2/alerts/{identifier}
+    * Deprecated POST /manage/groups/add in favor of POST /api/v2/manage/groups
     * Added documentation of missing GET /manage/severities/list
     * Added documentation of missing GET /manage/tlp/list
     * Added documentation of missing GET /manage/event-categories/list

--- a/docs/api_reference/reference/iris.v2.1.0.yaml
+++ b/docs/api_reference/reference/iris.v2.1.0.yaml
@@ -51,6 +51,7 @@ info:
     * Added PUT /api/v2/cases/{case_identifier}/events/{identifier}
     * Added DELETE /api/v2/cases/{case_identifier}/events/{identifier}
     * Added POST /api/v2/alerts
+    * Added GET /api/v2/alerts/{identifier}
     * Deprecated POST /manage/cases/add in favor of POST /api/v2/cases
     * Deprecated POST /manage/cases/update in favor of PUT /api/v2/cases/{case_identifier}
     * Deprecated POST /manage/cases/delete/{case_id} in favor of DELETE /api/v2/cases/{case_identifier}
@@ -136,6 +137,8 @@ paths:
     $ref: v2.1.0/resources/api_v2_cases_{case_identifier}_events_{identifier}.yaml
   /api/v2/alerts:
     $ref: v2.1.0/resources/api_v2_alerts.yaml
+  /api/v2/alerts/{identifier}:
+    $ref: v2.1.0/resources/api_v2_alerts_{identifier}.yaml    
   /manage/cases/update/{case_id}:
     $ref: v2.1.0/resources/manage_cases_update_{case_id}.yaml
   /api/v2/iocs/{identifier}:

--- a/docs/api_reference/reference/v2.1.0/resources/alerts_add.yaml
+++ b/docs/api_reference/reference/v2.1.0/resources/alerts_add.yaml
@@ -346,7 +346,9 @@ post:
                             type_name:
                               type: string
                             type_validation_regex:
-                              nullable: true
+                              type:
+                                - string
+                                - 'null'
                             type_id:
                               type: integer
                             type_description:

--- a/docs/api_reference/reference/v2.1.0/resources/alerts_{alert_id}.yaml
+++ b/docs/api_reference/reference/v2.1.0/resources/alerts_{alert_id}.yaml
@@ -7,6 +7,8 @@ parameters:
     description: Alert ID
 get:
   summary: Fetch an alert
+  description: This endpoint is deprecated. Use [GET /api/v2/alerts/{identifier}](#tag/Alerts/operation/api_v2_alerts_(identifier)_get) instead.
+  deprecated: true
   operationId: get-alerts-get
   responses:
     '200':
@@ -1343,6 +1345,5 @@ get:
                         type: array
                         items:
                           type: integer
-  description: Fetch an alert
   tags:
     - Alerts

--- a/docs/api_reference/reference/v2.1.0/resources/api_v2_alerts_{identifier}.yaml
+++ b/docs/api_reference/reference/v2.1.0/resources/api_v2_alerts_{identifier}.yaml
@@ -1,0 +1,22 @@
+parameters:
+  - $ref: ../parameters/path/identifier.yaml
+get:
+  operationId: api_v2_alerts_(identifier)_get
+  tags: 
+    - Alerts
+    - Beta
+  summary: Get an alert
+  description: Get an alert   
+  responses:
+    '201':
+      description: Alert successfully found
+      content:
+        application/json:
+          schema:
+            $ref: ../schemas/Alert.yaml
+    '400':
+      $ref: ../responses/GenericError.yaml
+    '403':
+      $ref: ../responses/Forbidden.yaml
+    '404':
+      $ref: ../responses/NotFound.yaml

--- a/docs/api_reference/reference/v2.1.0/resources/api_v2_cases_{case_identifier}_events.yaml
+++ b/docs/api_reference/reference/v2.1.0/resources/api_v2_cases_{case_identifier}_events.yaml
@@ -77,7 +77,7 @@ post:
           custom_attributes: {}
   responses:
     '201':
-      description: Evidence successfully created
+      description: Event successfully created
       content:
         application/json:
           schema:

--- a/docs/api_reference/reference/v2.1.0/resources/api_v2_groups.yaml
+++ b/docs/api_reference/reference/v2.1.0/resources/api_v2_groups.yaml
@@ -1,0 +1,38 @@
+post:
+  operationId: api_v2_groups_post
+  summary: Add a new group
+  description: Requires administrative rights.
+  tags:
+    - Groups
+    - Beta
+  requestBody:
+    content:
+      application/json:
+        schema:
+          type: object
+          properties:
+            group_name:
+              type: string
+            group_description:
+              type: string
+            group_permissions:
+              type: integer
+          required:
+            - group_name
+            - group_description
+        example:
+          group_name: New group
+          group_description: New description
+          group_permissions: 1
+  responses:
+    '201':
+      description: OK
+      content:
+        application/json:
+          schema:
+            $ref: ../schemas/Group.yaml
+    '400':
+      $ref: ../responses/GenericError.yaml
+    '403':
+      $ref: ../responses/Forbidden.yaml
+

--- a/docs/api_reference/reference/v2.1.0/resources/api_v2_manage_groups.yaml
+++ b/docs/api_reference/reference/v2.1.0/resources/api_v2_manage_groups.yaml
@@ -1,5 +1,5 @@
 post:
-  operationId: api_v2_groups_post
+  operationId: api_v2_manage_groups_post
   summary: Add a new group
   description: Requires administrative rights.
   tags:

--- a/docs/api_reference/reference/v2.1.0/resources/manage_groups_add.yaml
+++ b/docs/api_reference/reference/v2.1.0/resources/manage_groups_add.yaml
@@ -1,5 +1,8 @@
 post:
   summary: Add a new group
+  operationId: post-manage-groups-add
+  description: This endpoint is deprecated. Use [POST /api/v2/manage/groups/add](#tag/Groups/operation/api_v2_manage_groups_post) instead.
+  deprecated: true
   tags:
     - Groups
   responses:
@@ -57,8 +60,6 @@ post:
                   group_uuid: a9bb4b93-c8ac-490d-9387-f97f4722271c
                 message: ''
                 status: success
-  operationId: post-manage-groups-add
-  description: 'Requires administrative rights. '
   parameters:
     - schema:
         type: integer

--- a/docs/api_reference/reference/v2.1.0/schemas/Group.yaml
+++ b/docs/api_reference/reference/v2.1.0/schemas/Group.yaml
@@ -1,0 +1,28 @@
+type: object
+properties:
+  data:
+     type: object
+     properties:
+       group_name:
+         type: string
+       group_description:
+         type: string
+       group_permissions:
+         type: integer
+       group_auto_follow:
+         type: boolean
+       group_auto_follow_access_level:
+         type: integer
+       group_id:
+         type: integer
+       group_uuid:
+         type: string
+example:
+  group_auto_follow: false
+  group_auto_follow_access_level: 0
+  group_description: New description
+  group_id: 4
+  group_name: New group
+  group_permissions: 1
+  group_uuid: a9bb4b93-c8ac-490d-9387-f97f4722271c
+


### PR DESCRIPTION
Documentation of `POST /api/v2/manage/groups`.

* Deprecated `POST /manage/groups/add`
* Fixed a lint warning
* Fixed incorrect response description in response description in `api_v2_cases_{case_identifier}_events.yaml`

Note: this PR should be merged after [PR#58](https://github.com/dfir-iris/iris-doc-src/pull/58)