### PR TITLE
Api v2 get group

### DIFF
--- a/docs/api_reference/reference/.redocly.lint-ignore.yaml
+++ b/docs/api_reference/reference/.redocly.lint-ignore.yaml
@@ -304,8 +304,6 @@ v2.1.0/resources/alerts_add.yaml:
       #/post/responses/200/content/application~1json/schema/properties/data/properties/iocs/items/properties/user_id/nullable
     - >-
       #/post/responses/200/content/application~1json/schema/properties/data/properties/iocs/items/properties/ioc_misp/nullable
-    - >-
-      #/post/responses/200/content/application~1json/schema/properties/data/properties/iocs/items/properties/custom_attributes/nullable
   operation-4xx-response:
     - '#/post/responses'
   no-invalid-media-type-examples:

--- a/docs/api_reference/reference/iris.v2.1.0.yaml
+++ b/docs/api_reference/reference/iris.v2.1.0.yaml
@@ -468,7 +468,7 @@ tags:
   - name: Alerts
   - name: Customers
   - name: Users
-  - name: Groups
+  - name: Manage Groups
   - name: Modules
   - name: API
   - name: Beta

--- a/docs/api_reference/reference/iris.v2.1.0.yaml
+++ b/docs/api_reference/reference/iris.v2.1.0.yaml
@@ -53,6 +53,7 @@ info:
     * Added POST /api/v2/alerts
     * Added GET /api/v2/alerts/{identifier}
     * Added POST /api/v2/manage/groups
+    * Added GET /api/v2/manage/groups/{identifier}
     * Deprecated POST /manage/cases/add in favor of POST /api/v2/cases
     * Deprecated POST /manage/cases/update in favor of PUT /api/v2/cases/{case_identifier}
     * Deprecated POST /manage/cases/delete/{case_id} in favor of DELETE /api/v2/cases/{case_identifier}
@@ -144,6 +145,8 @@ paths:
     $ref: v2.1.0/resources/api_v2_alerts_{identifier}.yaml    
   /api/v2/manage/groups:
     $ref: v2.1.0/resources/api_v2_manage_groups.yaml
+  /api/v2/manage/groups/{identifier}:
+    $ref: v2.1.0/resources/api_v2_manage_groups_{identifier}.yaml
   /manage/cases/update/{case_id}:
     $ref: v2.1.0/resources/manage_cases_update_{case_id}.yaml
   /api/v2/iocs/{identifier}:

--- a/docs/api_reference/reference/v2.1.0/resources/alerts_add.yaml
+++ b/docs/api_reference/reference/v2.1.0/resources/alerts_add.yaml
@@ -339,7 +339,9 @@ post:
                         ioc_enrichment:
                           type: object
                         custom_attributes:
-                          nullable: true
+                          type:
+                            - object
+                            - 'null'
                         ioc_type:
                           type: object
                           properties:

--- a/docs/api_reference/reference/v2.1.0/resources/api_v2_manage_groups.yaml
+++ b/docs/api_reference/reference/v2.1.0/resources/api_v2_manage_groups.yaml
@@ -3,7 +3,7 @@ post:
   summary: Add a new group
   description: Requires administrative rights.
   tags:
-    - Groups
+    - Manage Groups
     - Beta
   requestBody:
     content:

--- a/docs/api_reference/reference/v2.1.0/resources/api_v2_manage_groups_{identifier}.yaml
+++ b/docs/api_reference/reference/v2.1.0/resources/api_v2_manage_groups_{identifier}.yaml
@@ -1,0 +1,23 @@
+parameters:
+  - $ref: ../parameters/path/identifier.yaml
+get:
+  operationId: api_v2_manage_groups_(identifier)_get
+  tags:
+    - Groups
+    - Beta
+  summary: Get a group
+  description: Requires administrative rights.
+  responses:
+    '201':
+      description: group successfully found
+      content:
+        application/json:
+          schema:
+            $ref: ../schemas/Group.yaml
+    '400':
+      $ref: ../responses/GenericError.yaml
+    '403':
+      $ref: ../responses/Forbidden.yaml
+    '404':
+      $ref: ../responses/NotFound.yaml
+

--- a/docs/api_reference/reference/v2.1.0/resources/api_v2_manage_groups_{identifier}.yaml
+++ b/docs/api_reference/reference/v2.1.0/resources/api_v2_manage_groups_{identifier}.yaml
@@ -3,7 +3,7 @@ parameters:
 get:
   operationId: api_v2_manage_groups_(identifier)_get
   tags:
-    - Groups
+    - Manage Groups
     - Beta
   summary: Get a group
   description: Requires administrative rights.

--- a/docs/api_reference/reference/v2.1.0/resources/manage_groups_add.yaml
+++ b/docs/api_reference/reference/v2.1.0/resources/manage_groups_add.yaml
@@ -1,10 +1,10 @@
 post:
   summary: Add a new group
   operationId: post-manage-groups-add
-  description: This endpoint is deprecated. Use [POST /api/v2/manage/groups/add](#tag/Groups/operation/api_v2_manage_groups_post) instead.
+  description: This endpoint is deprecated. Use [POST /api/v2/manage/groups/add](#tag/Manage-Groups/operation/api_v2_manage_groups_post) instead.
   deprecated: true
   tags:
-    - Groups
+    - Manage Groups
   responses:
     '200':
       description: OK

--- a/docs/api_reference/reference/v2.1.0/resources/manage_groups_delete_{group_id}.yaml
+++ b/docs/api_reference/reference/v2.1.0/resources/manage_groups_delete_{group_id}.yaml
@@ -1,7 +1,7 @@
 post:
   summary: Delete a Group
   tags:
-    - Groups
+    - Manage Groups
   responses:
     '200':
       description: OK

--- a/docs/api_reference/reference/v2.1.0/resources/manage_groups_list.yaml
+++ b/docs/api_reference/reference/v2.1.0/resources/manage_groups_list.yaml
@@ -1,7 +1,7 @@
 get:
   summary: List the groups
   tags:
-    - Groups
+    - Manage Groups
   responses: {}
   operationId: get-manage-groups-list
   description: List the groups

--- a/docs/api_reference/reference/v2.1.0/resources/manage_groups_update_{group_id}.yaml
+++ b/docs/api_reference/reference/v2.1.0/resources/manage_groups_update_{group_id}.yaml
@@ -1,7 +1,7 @@
 post:
   summary: Update a group
   tags:
-    - Groups
+    - Manage Groups
   responses:
     '200':
       description: OK

--- a/docs/api_reference/reference/v2.1.0/resources/manage_groups_{group_id}_cases-access_delete.yaml
+++ b/docs/api_reference/reference/v2.1.0/resources/manage_groups_{group_id}_cases-access_delete.yaml
@@ -1,7 +1,7 @@
 post:
   summary: Delete cases access of a group
   tags:
-    - Groups
+    - Manage Groups
   responses:
     '200':
       description: OK

--- a/docs/api_reference/reference/v2.1.0/resources/manage_groups_{group_id}_cases-access_update.yaml
+++ b/docs/api_reference/reference/v2.1.0/resources/manage_groups_{group_id}_cases-access_update.yaml
@@ -1,7 +1,7 @@
 post:
   summary: Set case access of a group
   tags:
-    - Groups
+    - Manage Groups
   responses:
     '200':
       description: OK

--- a/docs/api_reference/reference/v2.1.0/resources/manage_groups_{group_id}_members_delete_{user_id}.yaml
+++ b/docs/api_reference/reference/v2.1.0/resources/manage_groups_{group_id}_members_delete_{user_id}.yaml
@@ -1,7 +1,7 @@
 post:
   summary: Delete a member of a group
   tags:
-    - Groups
+    - Manage Groups
   responses:
     '200':
       description: OK

--- a/docs/api_reference/reference/v2.1.0/resources/manage_groups_{group_id}_members_update.yaml
+++ b/docs/api_reference/reference/v2.1.0/resources/manage_groups_{group_id}_members_update.yaml
@@ -1,7 +1,7 @@
 post:
   summary: Update group members
   tags:
-    - Groups
+    - Manage Groups
   responses:
     '200':
       description: OK

--- a/docs/api_reference/reference/v2.1.0/schemas/Group.yaml
+++ b/docs/api_reference/reference/v2.1.0/schemas/Group.yaml
@@ -1,22 +1,19 @@
 type: object
 properties:
-  data:
-     type: object
-     properties:
-       group_name:
-         type: string
-       group_description:
-         type: string
-       group_permissions:
-         type: integer
-       group_auto_follow:
-         type: boolean
-       group_auto_follow_access_level:
-         type: integer
-       group_id:
-         type: integer
-       group_uuid:
-         type: string
+  group_name:
+    type: string
+  group_description:
+    type: string
+  group_permissions:
+    type: integer
+  group_auto_follow:
+    type: boolean
+  group_auto_follow_access_level:
+    type: integer
+  group_id:
+    type: integer
+  group_uuid:
+    type: string
 example:
   group_auto_follow: false
   group_auto_follow_access_level: 0


### PR DESCRIPTION
Documentation of `GET /api/v2/manage/groups/{identifier}`.

* Deprecated `GET /manage/groups/{group_id}`
* use label `Manage Groups` instead of `Groups`
* fixed error in `Group` schema
* quality: fixed a lint warning