### PR TITLE
API v2 update alert

### DIFF
--- a/docs/api_reference/reference/.redocly.lint-ignore.yaml
+++ b/docs/api_reference/reference/.redocly.lint-ignore.yaml
@@ -304,8 +304,6 @@ v2.1.0/resources/alerts_add.yaml:
       #/post/responses/200/content/application~1json/schema/properties/data/properties/iocs/items/properties/user_id/nullable
     - >-
       #/post/responses/200/content/application~1json/schema/properties/data/properties/iocs/items/properties/ioc_misp/nullable
-    - >-
-      #/post/responses/200/content/application~1json/schema/properties/data/properties/iocs/items/properties/custom_attributes/nullable
   operation-4xx-response:
     - '#/post/responses'
   no-invalid-media-type-examples:

--- a/docs/api_reference/reference/iris.v2.1.0.yaml
+++ b/docs/api_reference/reference/iris.v2.1.0.yaml
@@ -52,6 +52,7 @@ info:
     * Added DELETE /api/v2/cases/{case_identifier}/events/{identifier}
     * Added POST /api/v2/alerts
     * Added GET /api/v2/alerts/{identifier}
+    * Added PUT /api/v2/alerts/{identifier}
     * Added POST /api/v2/manage/groups
     * Added GET /api/v2/manage/groups/{identifier}
     * Deprecated POST /manage/cases/add in favor of POST /api/v2/cases
@@ -84,8 +85,8 @@ info:
     * Deprecated POST /case/timeline/events/delete/{event_id} in favor of DELETE /api/v2/cases/{case_identifier}/events/{identifier}
     * Deprecated POST /alerts/add in favor of POST /api/v2/alerts
     * Deprecated GET /alerts/{alert_id} in favor of GET /api/v2/alerts/{identifier}
-    * Deprecated POST /manage/groups/add in favor of POST /api/v2/manage/groups
     * Deprecated POST /alert/update/{alert_id} in favor of PUT /api/v2/alerts/{identifier}
+    * Deprecated POST /manage/groups/add in favor of POST /api/v2/manage/groups
     * Added documentation of missing GET /manage/severities/list
     * Added documentation of missing GET /manage/tlp/list
     * Added documentation of missing GET /manage/event-categories/list

--- a/docs/api_reference/reference/iris.v2.1.0.yaml
+++ b/docs/api_reference/reference/iris.v2.1.0.yaml
@@ -85,6 +85,7 @@ info:
     * Deprecated POST /alerts/add in favor of POST /api/v2/alerts
     * Deprecated GET /alerts/{alert_id} in favor of GET /api/v2/alerts/{identifier}
     * Deprecated POST /manage/groups/add in favor of POST /api/v2/manage/groups
+    * Deprecated POST /alert/update/{alert_id} in favor of PUT /api/v2/alerts/{identifier}
     * Added documentation of missing GET /manage/severities/list
     * Added documentation of missing GET /manage/tlp/list
     * Added documentation of missing GET /manage/event-categories/list

--- a/docs/api_reference/reference/iris.v2.1.0.yaml
+++ b/docs/api_reference/reference/iris.v2.1.0.yaml
@@ -468,7 +468,7 @@ tags:
   - name: Alerts
   - name: Customers
   - name: Users
-  - name: Groups
+  - name: Manage Groups
   - name: Modules
   - name: API
   - name: Beta

--- a/docs/api_reference/reference/iris.v2.1.0.yaml
+++ b/docs/api_reference/reference/iris.v2.1.0.yaml
@@ -53,6 +53,7 @@ info:
     * Added POST /api/v2/alerts
     * Added GET /api/v2/alerts/{identifier}
     * Added POST /api/v2/manage/groups
+    * Added GET /api/v2/manage/groups/{identifier}
     * Deprecated POST /manage/cases/add in favor of POST /api/v2/cases
     * Deprecated POST /manage/cases/update in favor of PUT /api/v2/cases/{case_identifier}
     * Deprecated POST /manage/cases/delete/{case_id} in favor of DELETE /api/v2/cases/{case_identifier}
@@ -144,6 +145,8 @@ paths:
     $ref: v2.1.0/resources/api_v2_alerts_{identifier}.yaml    
   /api/v2/manage/groups:
     $ref: v2.1.0/resources/api_v2_manage_groups.yaml
+  /api/v2/manage/groups/{identifier}:
+    $ref: v2.1.0/resources/api_v2_manage_groups_{identifier}.yaml
   /manage/cases/update/{case_id}:
     $ref: v2.1.0/resources/manage_cases_update_{case_id}.yaml
   /api/v2/iocs/{identifier}:

--- a/docs/api_reference/reference/v2.1.0/resources/alerts_add.yaml
+++ b/docs/api_reference/reference/v2.1.0/resources/alerts_add.yaml
@@ -339,7 +339,9 @@ post:
                         ioc_enrichment:
                           type: object
                         custom_attributes:
-                          nullable: true
+                          type:
+                            - object
+                            - 'null'
                         ioc_type:
                           type: object
                           properties:

--- a/docs/api_reference/reference/v2.1.0/resources/alerts_update_{alert_id}.yaml
+++ b/docs/api_reference/reference/v2.1.0/resources/alerts_update_{alert_id}.yaml
@@ -1,5 +1,7 @@
 post:
   summary: Update an alert
+  description: This endpoint is deprecated. Use [PUT /api/v2/alerts/{identifier}](#tag/Alerts/operation/api_v2_alerts_(identifier)_put) instead.
+  deprecated: true
   operationId: post-case-update-alert
   responses:
     '200':
@@ -799,9 +801,6 @@ post:
                   alert_customer_id: 1
                   alert_classification_id: 1
                   alert_resolution_status_id: 1
-  description: >-
-    Update an existing alert. To update only specific fields one can send only
-    those fields. 
   parameters: []
   security:
     - Bearer <bearer>: []

--- a/docs/api_reference/reference/v2.1.0/resources/api_v2_alerts.yaml
+++ b/docs/api_reference/reference/v2.1.0/resources/api_v2_alerts.yaml
@@ -30,7 +30,7 @@ post:
             alert_status_id:
               $ref: ../schemas/alert_status_id.yaml
             alert_context:
-              type: object
+              $ref: ../schemas/alert_context.yaml
             alert_source_event_time:
               type: string
             alert_note:

--- a/docs/api_reference/reference/v2.1.0/resources/api_v2_alerts_{identifier}.yaml
+++ b/docs/api_reference/reference/v2.1.0/resources/api_v2_alerts_{identifier}.yaml
@@ -108,10 +108,7 @@ put:
             alert_status_id:
               $ref: ../schemas/alert_status_id.yaml
             alert_context:
-              type: object
-              properties:
-                context_key:
-                  type: string
+              $ref: ../schemas/alert_context.yaml
             alert_source_event_time:
               type: string
             alert_note:

--- a/docs/api_reference/reference/v2.1.0/resources/api_v2_alerts_{identifier}.yaml
+++ b/docs/api_reference/reference/v2.1.0/resources/api_v2_alerts_{identifier}.yaml
@@ -21,7 +21,7 @@ get:
     '404':
       $ref: ../responses/NotFound.yaml
 put:
-  operationId: api_v2_alerts_put
+  operationId: api_v2_alerts_(identifier)_put
   tags:
     - Alerts
     - Beta

--- a/docs/api_reference/reference/v2.1.0/resources/api_v2_alerts_{identifier}.yaml
+++ b/docs/api_reference/reference/v2.1.0/resources/api_v2_alerts_{identifier}.yaml
@@ -26,8 +26,199 @@ put:
     - Alerts
     - Beta
   summary: Update an alert
-  description:  Update an existing alert. To update only specific fields one can send only
-    those fields.
+  description:  Update an existing alert. To update only specific fields one can send only those fields.
+  requestBody:
+    content:
+      application/json:
+        schema:
+          type: object
+          properties:
+            alert_title:
+              type: string
+            alert_description:
+              type: string
+            alert_source:
+              type: string
+            alert_source_ref:
+              type: string
+            alert_source_link:
+              type: string
+            alert_source_content:
+              type: object
+              properties:
+                _id:
+                  type: string
+                contextId:
+                  type: string
+                description:
+                  type: string
+                entities:
+                  type: array
+                  items:
+                    type: object
+                    properties:
+                      entityRole:
+                        type: string
+                      entityType:
+                        type: integer
+                      id:
+                        type: string
+                      inst:
+                        type: integer
+                      label:
+                        type: string
+                      pa:
+                        type: string
+                      saas:
+                        type: integer
+                      type:
+                        type: string
+                      policyType:
+                        type: string
+                idValue:
+                  type: integer
+                isSystemAlert:
+                  type: boolean
+                resolutionStatusValue:
+                  type: integer
+                severityValue:
+                  type: integer
+                statusValue:
+                  type: integer
+                stories:
+                  type: array
+                  items:
+                    type: integer
+                threatScore:
+                  type: integer
+                timestamp:
+                  type: integer
+                title:
+                  type: string
+                comment:
+                  type: string
+                handledByUser:
+                  type: string
+                resolveTime:
+                  type: string
+                URL:
+                  type: string
+            alert_severity_id:
+              $ref: ../schemas/severity_id.yaml
+            alert_status_id:
+              $ref: ../schemas/alert_status_id.yaml
+            alert_context:
+              type: object
+              properties:
+                context_key:
+                  type: string
+            alert_source_event_time:
+              type: string
+            alert_note:
+              type: string
+            alert_tags:
+              type: string
+            alert_assets:
+              type: array
+              items:
+                type: object
+                properties:
+                  asset_name:
+                    type: string
+                  asset_description:
+                    type: string
+                  asset_type_id:
+                    type: integer
+                  asset_ip:
+                    type: string
+                  asset_domain:
+                    type: string
+                  asset_tags:
+                    type: string
+                  asset_enrichment:
+                    type: object
+                    properties:
+                      enrich1:
+                        type: object
+                        properties:
+                          A key:
+                            type: string
+            alert_customer_id:
+              type: integer
+            alert_classification_id:
+              $ref: ../schemas/classification_id.yaml
+        example:
+          alert_title: Low-reputation arbitrary code executed by signed executable
+          alert_description: This is a test alert, courtesy of MS
+          alert_source: Test Source
+          alert_source_ref: Test-123
+          alert_source_link: https://source_link.com
+          alert_source_content:
+            _id: 603f704aaf7417985bbf3b22
+            contextId: 206e2965-6533-48a6-ba9e-794364a84bf9
+            description: >-
+              Contoso user performed 11 suspicious activities MITRE
+              Technique used Account Discovery (T1087) and subtechnique used
+              Domain Account (T1087.002)
+            entities:
+              - entityRole: Source
+                entityType: 2
+                id: 6204bdaf-ad46-4e99-a25d-374a0532c666
+                inst: 0
+                label: user1
+                pa: user1@contoso.com
+                saas: 11161
+                type: account
+              - entityRole: Related
+                id: 55017817-27af-49a7-93d6-8af6c5030fdb
+                label: DC3
+                type: device
+              - id: 20940
+                label: Active Directory
+                type: service
+              - entityRole: Related
+                id: 95c59b48-98c1-40ff-a444-d9040f1f68f2
+                label: DC4
+                type: device
+              - id: 5bfd18bfab73c36ba10d38ca
+                label: Honeytoken activity
+                policyType: ANOMALY_DETECTION
+                type: policyRule
+              - entityRole: Source
+                id: 34f3ecc9-6903-4df7-af79-14fe2d0d4553
+                label: Client1
+                type: device
+              - entityRole: Related
+                id: d68772fe-1171-4124-9f73-0f410340bd54
+                label: DC1
+                type: device
+              - type: groupTag
+                id: 5f759b4d106abbe4a504ea5d
+                label: All Users
+            idValue: 15795464
+            isSystemAlert: false
+            resolutionStatusValue: 0
+            severityValue: 5
+            statusValue: 1
+            stories:
+              - 0
+            threatScore: 34
+            timestamp: 1621941916475
+            title: Honeytoken activity
+            comment: ''
+            handledByUser: administrator@contoso.com
+            resolveTime: '2021-05-13T14:02:34.904Z'
+            URL: https://contoso.portal.cloudappsecurity.com/#/alerts/603f704aaf7417985bbf3b22
+          alert_severity_id: 4
+          alert_status_id: 3
+          alert_context:
+            context_key: context_value
+          alert_source_event_time: '2023-03-26T03:00:30'
+          alert_note: A note on
+          alert_tags: defender,anothertag
+          alert_customer_id: 1
+          alert_classification_id: 1
+    description: ''
   responses:
     '201':
       description: Alert successfully updated

--- a/docs/api_reference/reference/v2.1.0/resources/api_v2_alerts_{identifier}.yaml
+++ b/docs/api_reference/reference/v2.1.0/resources/api_v2_alerts_{identifier}.yaml
@@ -20,3 +20,24 @@ get:
       $ref: ../responses/Forbidden.yaml
     '404':
       $ref: ../responses/NotFound.yaml
+put:
+  operationId: api_v2_alerts_put
+  tags:
+    - Alerts
+    - Beta
+  summary: Update an alert
+  description:  Update an existing alert. To update only specific fields one can send only
+    those fields.
+  responses:
+    '201':
+      description: Alert successfully updated
+      content:
+        application/json:
+          schema:
+            $ref: ../schemas/Alert.yaml
+    '400':
+      $ref: ../responses/GenericError.yaml
+    '403':
+      $ref: ../responses/Forbidden.yaml
+    '404':
+      $ref: ../responses/NotFound.yaml

--- a/docs/api_reference/reference/v2.1.0/resources/api_v2_alerts_{identifier}.yaml
+++ b/docs/api_reference/reference/v2.1.0/resources/api_v2_alerts_{identifier}.yaml
@@ -170,9 +170,6 @@ put:
                 id: 55017817-27af-49a7-93d6-8af6c5030fdb
                 label: DC3
                 type: device
-              - id: 20940
-                label: Active Directory
-                type: service
               - entityRole: Related
                 id: 95c59b48-98c1-40ff-a444-d9040f1f68f2
                 label: DC4
@@ -189,9 +186,6 @@ put:
                 id: d68772fe-1171-4124-9f73-0f410340bd54
                 label: DC1
                 type: device
-              - type: groupTag
-                id: 5f759b4d106abbe4a504ea5d
-                label: All Users
             idValue: 15795464
             isSystemAlert: false
             resolutionStatusValue: 0

--- a/docs/api_reference/reference/v2.1.0/resources/api_v2_manage_groups.yaml
+++ b/docs/api_reference/reference/v2.1.0/resources/api_v2_manage_groups.yaml
@@ -3,7 +3,7 @@ post:
   summary: Add a new group
   description: Requires administrative rights.
   tags:
-    - Groups
+    - Manage Groups
     - Beta
   requestBody:
     content:

--- a/docs/api_reference/reference/v2.1.0/resources/api_v2_manage_groups_{identifier}.yaml
+++ b/docs/api_reference/reference/v2.1.0/resources/api_v2_manage_groups_{identifier}.yaml
@@ -1,0 +1,23 @@
+parameters:
+  - $ref: ../parameters/path/identifier.yaml
+get:
+  operationId: api_v2_manage_groups_(identifier)_get
+  tags:
+    - Groups
+    - Beta
+  summary: Get a group
+  description: Requires administrative rights.
+  responses:
+    '201':
+      description: group successfully found
+      content:
+        application/json:
+          schema:
+            $ref: ../schemas/Group.yaml
+    '400':
+      $ref: ../responses/GenericError.yaml
+    '403':
+      $ref: ../responses/Forbidden.yaml
+    '404':
+      $ref: ../responses/NotFound.yaml
+

--- a/docs/api_reference/reference/v2.1.0/resources/api_v2_manage_groups_{identifier}.yaml
+++ b/docs/api_reference/reference/v2.1.0/resources/api_v2_manage_groups_{identifier}.yaml
@@ -3,7 +3,7 @@ parameters:
 get:
   operationId: api_v2_manage_groups_(identifier)_get
   tags:
-    - Groups
+    - Manage Groups
     - Beta
   summary: Get a group
   description: Requires administrative rights.

--- a/docs/api_reference/reference/v2.1.0/resources/manage_groups_add.yaml
+++ b/docs/api_reference/reference/v2.1.0/resources/manage_groups_add.yaml
@@ -1,10 +1,10 @@
 post:
   summary: Add a new group
   operationId: post-manage-groups-add
-  description: This endpoint is deprecated. Use [POST /api/v2/manage/groups/add](#tag/Groups/operation/api_v2_manage_groups_post) instead.
+  description: This endpoint is deprecated. Use [POST /api/v2/manage/groups/add](#tag/Manage-Groups/operation/api_v2_manage_groups_post) instead.
   deprecated: true
   tags:
-    - Groups
+    - Manage Groups
   responses:
     '200':
       description: OK

--- a/docs/api_reference/reference/v2.1.0/resources/manage_groups_delete_{group_id}.yaml
+++ b/docs/api_reference/reference/v2.1.0/resources/manage_groups_delete_{group_id}.yaml
@@ -1,7 +1,7 @@
 post:
   summary: Delete a Group
   tags:
-    - Groups
+    - Manage Groups
   responses:
     '200':
       description: OK

--- a/docs/api_reference/reference/v2.1.0/resources/manage_groups_list.yaml
+++ b/docs/api_reference/reference/v2.1.0/resources/manage_groups_list.yaml
@@ -1,7 +1,7 @@
 get:
   summary: List the groups
   tags:
-    - Groups
+    - Manage Groups
   responses: {}
   operationId: get-manage-groups-list
   description: List the groups

--- a/docs/api_reference/reference/v2.1.0/resources/manage_groups_update_{group_id}.yaml
+++ b/docs/api_reference/reference/v2.1.0/resources/manage_groups_update_{group_id}.yaml
@@ -1,7 +1,7 @@
 post:
   summary: Update a group
   tags:
-    - Groups
+    - Manage Groups
   responses:
     '200':
       description: OK

--- a/docs/api_reference/reference/v2.1.0/resources/manage_groups_{group_id}_cases-access_delete.yaml
+++ b/docs/api_reference/reference/v2.1.0/resources/manage_groups_{group_id}_cases-access_delete.yaml
@@ -1,7 +1,7 @@
 post:
   summary: Delete cases access of a group
   tags:
-    - Groups
+    - Manage Groups
   responses:
     '200':
       description: OK

--- a/docs/api_reference/reference/v2.1.0/resources/manage_groups_{group_id}_cases-access_update.yaml
+++ b/docs/api_reference/reference/v2.1.0/resources/manage_groups_{group_id}_cases-access_update.yaml
@@ -1,7 +1,7 @@
 post:
   summary: Set case access of a group
   tags:
-    - Groups
+    - Manage Groups
   responses:
     '200':
       description: OK

--- a/docs/api_reference/reference/v2.1.0/resources/manage_groups_{group_id}_members_delete_{user_id}.yaml
+++ b/docs/api_reference/reference/v2.1.0/resources/manage_groups_{group_id}_members_delete_{user_id}.yaml
@@ -1,7 +1,7 @@
 post:
   summary: Delete a member of a group
   tags:
-    - Groups
+    - Manage Groups
   responses:
     '200':
       description: OK

--- a/docs/api_reference/reference/v2.1.0/resources/manage_groups_{group_id}_members_update.yaml
+++ b/docs/api_reference/reference/v2.1.0/resources/manage_groups_{group_id}_members_update.yaml
@@ -1,7 +1,7 @@
 post:
   summary: Update group members
   tags:
-    - Groups
+    - Manage Groups
   responses:
     '200':
       description: OK

--- a/docs/api_reference/reference/v2.1.0/schemas/Alert.yaml
+++ b/docs/api_reference/reference/v2.1.0/schemas/Alert.yaml
@@ -17,7 +17,7 @@ properties:
   alert_status_id:
     $ref: ../schemas/alert_status_id.yaml
   alert_context:
-    type: object
+    $ref: ../schemas/alert_context.yaml
   alert_source_event_time:
     type: string
   alert_note:

--- a/docs/api_reference/reference/v2.1.0/schemas/Alert.yaml
+++ b/docs/api_reference/reference/v2.1.0/schemas/Alert.yaml
@@ -10,6 +10,8 @@ properties:
     type: string
   alert_source_link:
     type: string
+  alert_source_content:
+    type: object
   alert_severity_id:
     $ref: ../schemas/severity_id.yaml
   alert_status_id:
@@ -64,8 +66,6 @@ properties:
       oneOf:
       - $ref: ../schemas/classification_id.yaml
       - type: 'null'
-  alert_source_content:
-    type: object
 example:
   alert_title: Low-reputation arbitrary code executed by signed executable
   alert_description: This is a test alert, courtesy of MS

--- a/docs/api_reference/reference/v2.1.0/schemas/Group.yaml
+++ b/docs/api_reference/reference/v2.1.0/schemas/Group.yaml
@@ -1,22 +1,19 @@
 type: object
 properties:
-  data:
-     type: object
-     properties:
-       group_name:
-         type: string
-       group_description:
-         type: string
-       group_permissions:
-         type: integer
-       group_auto_follow:
-         type: boolean
-       group_auto_follow_access_level:
-         type: integer
-       group_id:
-         type: integer
-       group_uuid:
-         type: string
+  group_name:
+    type: string
+  group_description:
+    type: string
+  group_permissions:
+    type: integer
+  group_auto_follow:
+    type: boolean
+  group_auto_follow_access_level:
+    type: integer
+  group_id:
+    type: integer
+  group_uuid:
+    type: string
 example:
   group_auto_follow: false
   group_auto_follow_access_level: 0

--- a/docs/api_reference/reference/v2.1.0/schemas/alert_context.yaml
+++ b/docs/api_reference/reference/v2.1.0/schemas/alert_context.yaml
@@ -1,0 +1,4 @@
+type: object
+properties:
+  context_key:
+    type: string


### PR DESCRIPTION
Documentation of `PUT /api/v2/alerts/{identifier}`

* documentation of `POST /alert/update/{alert_id}` deprecation
* added schema `alert_context` to refactor

Note: this PR should be merged after [PR#60](https://github.com/dfir-iris/iris-doc-src/pull/60)