### PR TITLE
Api v2 delete comments

### DIFF
--- a/docs/api_reference/reference/.redocly.lint-ignore.yaml
+++ b/docs/api_reference/reference/.redocly.lint-ignore.yaml
@@ -3,15 +3,6 @@
 iris.v2.1.0.yaml:
   spec-components-invalid-map-name:
     - '#/components/securitySchemes/Bearer <bearer>'
-v2.1.0/resources/api_v2_cases.yaml:
-  operation-4xx-response:
-    - '#/get/responses'
-v2.1.0/resources/api_v2_cases_{case_identifier}_iocs.yaml:
-  operation-4xx-response:
-    - '#/get/responses'
-v2.1.0/resources/api_v2_cases_{case_identifier}_assets.yaml:
-  operation-4xx-response:
-    - '#/get/responses'
 v2.1.0/resources/case_summary_update.yaml:
   no-invalid-media-type-examples:
     - '#/post/requestBody/content/application~1json/examples/example-1/value/cid'

--- a/docs/api_reference/reference/.redocly.lint-ignore.yaml
+++ b/docs/api_reference/reference/.redocly.lint-ignore.yaml
@@ -12,14 +12,6 @@ v2.1.0/resources/api_v2_cases_{case_identifier}_iocs.yaml:
 v2.1.0/resources/api_v2_cases_{case_identifier}_assets.yaml:
   operation-4xx-response:
     - '#/get/responses'
-v2.1.0/resources/api_v2_cases_{case_identifier}_assets_{identifier}.yaml:
-  no-invalid-media-type-examples:
-    - >-
-      #/put/requestBody/content/application~1json/examples/Example
-      1/value/analysis_status_id
-v2.1.0/resources/api_v2_cases_{case_identifier}_tasks.yaml:
-  operation-4xx-response:
-    - '#/get/responses'
 v2.1.0/resources/case_summary_update.yaml:
   no-invalid-media-type-examples:
     - '#/post/requestBody/content/application~1json/examples/example-1/value/cid'

--- a/docs/api_reference/reference/iris.v2.1.0.yaml
+++ b/docs/api_reference/reference/iris.v2.1.0.yaml
@@ -523,7 +523,7 @@ tags:
     description: Endpoints to interact with alerts
   - name: Customers
     description: Endpoints to interact with customers
-  - name: Users
+  - name: Manage Users
     description: Endpoints to interact with users
   - name: Manage Groups
     description: Endpoints to interact with groups

--- a/docs/api_reference/reference/iris.v2.1.0.yaml
+++ b/docs/api_reference/reference/iris.v2.1.0.yaml
@@ -72,6 +72,7 @@ info:
     * Added GET /api/v2/{objects}/{object_identifier}/comments
     * Added POST /api/v2/{objects}/{object_identifier}/comments
     * Added GET /api/v2/{objects}/{object_identifier}/comments/{identifier}
+    * Added DELETE /api/v2/{objects}/{object_identifier}/comments/{identifier}
     * Deprecated POST /manage/cases/add in favor of POST /api/v2/cases
     * Deprecated POST /manage/cases/update in favor of PUT /api/v2/cases/{case_identifier}
     * Deprecated POST /manage/cases/delete/{case_id} in favor of DELETE /api/v2/cases/{case_identifier}
@@ -523,6 +524,8 @@ tags:
     description: Endpoints to interact with alerts
   - name: Customers
     description: Endpoints to interact with customers
+  - name: Comments
+    description: Endpoints to interact with comments
   - name: Manage Users
     description: Endpoints to interact with users
   - name: Manage Groups

--- a/docs/api_reference/reference/iris.v2.1.0.yaml
+++ b/docs/api_reference/reference/iris.v2.1.0.yaml
@@ -70,6 +70,7 @@ info:
     * Added GET /api/v2/me
     * Added PUT /api/v2/me
     * Added GET /api/v2/{objects}/{object_identifier}/comments
+    * Added POST /api/v2/{objects}/{object_identifier}/comments
     * Deprecated POST /manage/cases/add in favor of POST /api/v2/cases
     * Deprecated POST /manage/cases/update in favor of PUT /api/v2/cases/{case_identifier}
     * Deprecated POST /manage/cases/delete/{case_id} in favor of DELETE /api/v2/cases/{case_identifier}

--- a/docs/api_reference/reference/iris.v2.1.0.yaml
+++ b/docs/api_reference/reference/iris.v2.1.0.yaml
@@ -115,6 +115,7 @@ info:
     * Deprecated POST /manage/users/delete/{user_id} in favor of  DELETE /api/v2/manage/users/{identifier}
     * Deprecated GET /alerts/similarities/{alert_id}
     * Deprecated GET /case/{object_name}/{object_id}/comments/list
+    * Deprecated POST /case/{object_name}/{object_id}/comments/add
     * Added documentation of missing GET /manage/severities/list
     * Added documentation of missing GET /manage/tlp/list
     * Added documentation of missing GET /manage/event-categories/list

--- a/docs/api_reference/reference/iris.v2.1.0.yaml
+++ b/docs/api_reference/reference/iris.v2.1.0.yaml
@@ -69,6 +69,7 @@ info:
     * Added DELETE /api/v2/manage/users/{identifier}
     * Added GET /api/v2/me
     * Added PUT /api/v2/me
+    * Added GET /api/v2/{objects}/{object_identifier}/comments
     * Deprecated POST /manage/cases/add in favor of POST /api/v2/cases
     * Deprecated POST /manage/cases/update in favor of PUT /api/v2/cases/{case_identifier}
     * Deprecated POST /manage/cases/delete/{case_id} in favor of DELETE /api/v2/cases/{case_identifier}
@@ -171,6 +172,8 @@ paths:
     $ref: v2.1.0/resources/api_v2_cases_{case_identifier}_events.yaml
   /api/v2/cases/{case_identifier}/events/{identifier}:
     $ref: v2.1.0/resources/api_v2_cases_{case_identifier}_events_{identifier}.yaml
+  /api/v2/{objects}/{object_identifier}/comments:
+    $ref: v2.1.0/resources/api_v2_{objects}_{object_identifier}_comments.yaml
   /api/v2/alerts:
     $ref: v2.1.0/resources/api_v2_alerts.yaml
   /api/v2/alerts/{identifier}:

--- a/docs/api_reference/reference/iris.v2.1.0.yaml
+++ b/docs/api_reference/reference/iris.v2.1.0.yaml
@@ -71,6 +71,7 @@ info:
     * Added PUT /api/v2/me
     * Added GET /api/v2/{objects}/{object_identifier}/comments
     * Added POST /api/v2/{objects}/{object_identifier}/comments
+    * Added GET /api/v2/{objects}/{object_identifier}/comments/{identifier}
     * Deprecated POST /manage/cases/add in favor of POST /api/v2/cases
     * Deprecated POST /manage/cases/update in favor of PUT /api/v2/cases/{case_identifier}
     * Deprecated POST /manage/cases/delete/{case_id} in favor of DELETE /api/v2/cases/{case_identifier}
@@ -177,6 +178,8 @@ paths:
     $ref: v2.1.0/resources/api_v2_cases_{case_identifier}_events_{identifier}.yaml
   /api/v2/{objects}/{object_identifier}/comments:
     $ref: v2.1.0/resources/api_v2_{objects}_{object_identifier}_comments.yaml
+  /api/v2/{objects}/{object_identifier}/comments/{identifier}:
+    $ref: v2.1.0/resources/api_v2_{objects}_{object_identifier}_comments_{identifier}.yaml
   /api/v2/alerts:
     $ref: v2.1.0/resources/api_v2_alerts.yaml
   /api/v2/alerts/{identifier}:

--- a/docs/api_reference/reference/iris.v2.1.0.yaml
+++ b/docs/api_reference/reference/iris.v2.1.0.yaml
@@ -113,6 +113,7 @@ info:
     * Deprecated POST /manage/users/update/{user_id} in favor of  PUT /api/v2/manage/users/{identifier}
     * Deprecated POST /manage/users/delete/{user_id} in favor of  DELETE /api/v2/manage/users/{identifier}
     * Deprecated GET /alerts/similarities/{alert_id}
+    * Deprecated GET /case/{object_name}/{object_id}/comments/list
     * Added documentation of missing GET /manage/severities/list
     * Added documentation of missing GET /manage/tlp/list
     * Added documentation of missing GET /manage/event-categories/list

--- a/docs/api_reference/reference/iris.v2.1.0.yaml
+++ b/docs/api_reference/reference/iris.v2.1.0.yaml
@@ -118,6 +118,7 @@ info:
     * Deprecated GET /alerts/similarities/{alert_id}
     * Deprecated GET /case/{object_name}/{object_id}/comments/list
     * Deprecated POST /case/{object_name}/{object_id}/comments/add
+    * Deprecated DELETE /case/{object_name}/{object_id}/comments/{comment_id}/delete
     * Added documentation of missing GET /manage/severities/list
     * Added documentation of missing GET /manage/tlp/list
     * Added documentation of missing GET /manage/event-categories/list

--- a/docs/api_reference/reference/iris.v2.1.0.yaml
+++ b/docs/api_reference/reference/iris.v2.1.0.yaml
@@ -118,7 +118,7 @@ info:
     * Deprecated GET /alerts/similarities/{alert_id}
     * Deprecated GET /case/{object_name}/{object_id}/comments/list
     * Deprecated POST /case/{object_name}/{object_id}/comments/add
-    * Deprecated DELETE /case/{object_name}/{object_id}/comments/{comment_id}/delete
+    * Deprecated POST /case/{object_name}/{object_id}/comments/{comment_id}/delete
     * Added documentation of missing GET /manage/severities/list
     * Added documentation of missing GET /manage/tlp/list
     * Added documentation of missing GET /manage/event-categories/list

--- a/docs/api_reference/reference/v2.1.0/resources/api_v2_cases.yaml
+++ b/docs/api_reference/reference/v2.1.0/resources/api_v2_cases.yaml
@@ -52,10 +52,10 @@ post:
         application/json:
           schema:
             $ref: ../schemas/Case.yaml
-    '403':
-      $ref: ../responses/Forbidden.yaml
     '400':
       $ref: ../responses/GenericError.yaml
+    '403':
+      $ref: ../responses/Forbidden.yaml
 get:
   operationId: api_v2_cases_get
   summary: Get a paginated list of cases
@@ -85,6 +85,8 @@ get:
         application/json:
           schema:
             $ref: ../schemas/Cases.yaml
+    '400':
+      $ref: ../responses/GenericError.yaml
   tags:
     - Cases
     - Beta

--- a/docs/api_reference/reference/v2.1.0/resources/api_v2_cases_{case_identifier}_assets_{identifier}.yaml
+++ b/docs/api_reference/reference/v2.1.0/resources/api_v2_cases_{case_identifier}_assets_{identifier}.yaml
@@ -68,7 +68,7 @@ put:
               asset_ip: 127.0.0.1
               asset_info: ''
               asset_compromise_status_id: 1
-              analysis_status_id: '3'
+              analysis_status_id: 3
               ioc_links:
                 - '30'
               asset_tags: anewtag

--- a/docs/api_reference/reference/v2.1.0/resources/api_v2_{objects}_{object_identifier}_comments.yaml
+++ b/docs/api_reference/reference/v2.1.0/resources/api_v2_{objects}_{object_identifier}_comments.yaml
@@ -1,0 +1,45 @@
+parameters:
+  - schema:
+      type: string
+      enum:
+        - alerts
+        - assets
+        - events
+        - evidences
+        - iocs
+        - notes
+        - tasks
+    name: objects
+    in: path
+    required: true
+    description: Type of commented object
+  - schema:
+      type: integer
+    name: object_identifier
+    in: path
+    required: true
+    description: Identifier of the commented object
+get:
+  operationId: api_v2_(objects)_(object_identifier)_comments_get
+  summary: Get a paginated list of comments
+  description: Get a paginated list of comments
+  tags:
+    - Comments
+    - Beta
+  parameters:
+    - $ref: ../parameters/query/page.yaml
+    - $ref: ../parameters/query/per_page.yaml
+  responses:
+    '200':
+      description: Paginated list of comments
+      content:
+        application/json:
+          schema:
+            $ref: ../schemas/Comments.yaml
+    '400':
+      $ref: ../responses/GenericError.yaml
+    '403':
+      $ref: ../responses/Forbidden.yaml
+    '404':
+      $ref: ../responses/NotFound.yaml
+

--- a/docs/api_reference/reference/v2.1.0/resources/api_v2_{objects}_{object_identifier}_comments.yaml
+++ b/docs/api_reference/reference/v2.1.0/resources/api_v2_{objects}_{object_identifier}_comments.yaml
@@ -42,4 +42,29 @@ get:
       $ref: ../responses/Forbidden.yaml
     '404':
       $ref: ../responses/NotFound.yaml
+post:
+  operationId: api_v2_(objects)_(object_identifier)_comments_post
+  summary: Add a new comment to a case object
+  description: Add a new comment to a case object
+  tags:
+    - Comments
+    - Beta
+  requestBody:
+    content:
+      application/json:
+        schema:
+          $ref: ../schemas/requestBodies/Comment.yaml
+  responses:
+    '201':
+      description: Comment successfully created
+      content:
+        application/json:
+          schema:
+            $ref: ../schemas/Comment.yaml
+    '400':
+      $ref: ../responses/GenericError.yaml
+    '403':
+      $ref: ../responses/Forbidden.yaml
+    '404':
+      description: Object with identifier `object_identifier` not found
 

--- a/docs/api_reference/reference/v2.1.0/resources/api_v2_{objects}_{object_identifier}_comments_{identifier}.yaml
+++ b/docs/api_reference/reference/v2.1.0/resources/api_v2_{objects}_{object_identifier}_comments_{identifier}.yaml
@@ -45,4 +45,20 @@ get:
       $ref: ../responses/Forbidden.yaml
     '404':
       $ref: ../responses/NotFound.yaml
+delete:
+  operationId: api_v2_(objects)_(object_identifier)_comments_(identifier)_delete
+  summary: Delete a comment
+  description: Delete a comment
+  tags:
+    - Comments
+    - Beta
+  responses:
+    '204':
+      $ref: ../responses/Deleted.yaml
+    '400':
+      $ref: ../responses/GenericError.yaml
+    '403':
+      $ref: ../responses/Forbidden.yaml
+    '404':
+      $ref: ../responses/NotFound.yaml
 

--- a/docs/api_reference/reference/v2.1.0/resources/api_v2_{objects}_{object_identifier}_comments_{identifier}.yaml
+++ b/docs/api_reference/reference/v2.1.0/resources/api_v2_{objects}_{object_identifier}_comments_{identifier}.yaml
@@ -1,0 +1,48 @@
+parameters:
+  - schema:
+      type: string
+      enum:
+        - alerts
+        - assets
+        - events
+        - evidences
+        - iocs
+        - notes
+        - tasks
+    name: objects
+    in: path
+    required: true
+    description: Type of commented object
+  - schema:
+      type: integer
+    name: object_identifier
+    in: path
+    required: true
+    description: Identifier of the commented object
+  - schema:
+      type: integer
+    name: identifier
+    in: path
+    required: true
+    description: Identifier of the comment
+get:
+  operationId: api_v2_(objects)_(object_identifier)_comments_(identifier)_get
+  summary: Get a comment
+  description: Get a comment
+  tags:
+    - Comments
+    - Beta
+  responses:
+    '200':
+      description: Comment successfully found
+      content:
+        application/json:
+          schema:
+            $ref: ../schemas/Comment.yaml
+    '400':
+      $ref: ../responses/GenericError.yaml
+    '403':
+      $ref: ../responses/Forbidden.yaml
+    '404':
+      $ref: ../responses/NotFound.yaml
+

--- a/docs/api_reference/reference/v2.1.0/resources/case_{object_name}_{object_id}_comments_add.yaml
+++ b/docs/api_reference/reference/v2.1.0/resources/case_{object_name}_{object_id}_comments_add.yaml
@@ -79,7 +79,8 @@ post:
                 message: ''
                 status: success
   operationId: post-case-object_name-object_id-comments-add
-  description: Add a new comment to a case object
+  description: This endpoint is deprecated. Use [POST /api/v2/{objects}/{object_identifier}](#tag/Comments/operation/api_v2_(objects)_(object_identifier)_comments_post) instead.
+  deprecated: true
   requestBody:
     content:
       application/json:

--- a/docs/api_reference/reference/v2.1.0/resources/case_{object_name}_{object_id}_comments_list.yaml
+++ b/docs/api_reference/reference/v2.1.0/resources/case_{object_name}_{object_id}_comments_list.yaml
@@ -79,4 +79,5 @@ get:
                 message: ''
                 status: success
   operationId: get-case-object_name-object_id-comments-list
-  description: List the comments a case object
+  description: This endpoint is deprecated. Use [GET /api/v2/{objects}/{object_identifier}](#tag/Comments/operation/api_v2_(objects)_(object_identifier)_comments_get) instead.
+  deprecated: true

--- a/docs/api_reference/reference/v2.1.0/resources/case_{object_name}_{object_id}_comments_{comment_id}_delete.yaml
+++ b/docs/api_reference/reference/v2.1.0/resources/case_{object_name}_{object_id}_comments_{comment_id}_delete.yaml
@@ -57,4 +57,6 @@ post:
                 message: Comment deleted
                 status: success
   operationId: post-case-object_name-object_id-comments-comment_id-delete
-  description: ''
+  description: This endpoint is deprecated. Use [DELETE /api/v2/{objects}/{object_identifier}](#tag/Comments/operation/api_v2_(objects)_(object_identifier)_comments_(identifier)_delete) instead.
+  deprecated: true
+

--- a/docs/api_reference/reference/v2.1.0/schemas/Comment.yaml
+++ b/docs/api_reference/reference/v2.1.0/schemas/Comment.yaml
@@ -1,19 +1,18 @@
-type: object
-properties:
-  comment_id:
-    type: integer
-  comment_uuid:
-    type: string
-  comment_text:
-    type: string
-  comment_date:
-    type: string
-  comment_update_date:
-    type: string
-example:
-  comment_id: 12
-  comment_uuid: f43d28a7-cd07-48ec-a602-26e0ce21743b
-  comment_text: 'No '
-  comment_date: Mon, 20 Mar 2023 17:12:06 GMT
-  comment_update_date: Mon, 20 Mar 2023 17:12:06 GMT
+allOf:
+  - $ref: ../schemas/requestBodies/Comment.yaml
+  - type: object
+    properties:
+      comment_id:
+        type: integer
+      comment_uuid:
+        type: string
+      comment_date:
+        type: string
+      comment_update_date:
+        type: string
+    example:
+      comment_id: 12
+      comment_uuid: f43d28a7-cd07-48ec-a602-26e0ce21743b
+      comment_date: Mon, 20 Mar 2023 17:12:06 GMT
+      comment_update_date: Mon, 20 Mar 2023 17:12:06 GMT
 

--- a/docs/api_reference/reference/v2.1.0/schemas/Comment.yaml
+++ b/docs/api_reference/reference/v2.1.0/schemas/Comment.yaml
@@ -1,0 +1,19 @@
+type: object
+properties:
+  comment_id:
+    type: integer
+  comment_uuid:
+    type: string
+  comment_text:
+    type: string
+  comment_date:
+    type: string
+  comment_update_date:
+    type: string
+example:
+  comment_id: 12
+  comment_uuid: f43d28a7-cd07-48ec-a602-26e0ce21743b
+  comment_text: 'No '
+  comment_date: Mon, 20 Mar 2023 17:12:06 GMT
+  comment_update_date: Mon, 20 Mar 2023 17:12:06 GMT
+

--- a/docs/api_reference/reference/v2.1.0/schemas/Comments.yaml
+++ b/docs/api_reference/reference/v2.1.0/schemas/Comments.yaml
@@ -1,0 +1,17 @@
+type: object
+properties:
+  total:
+    type: integer
+  data:
+    type: array
+    items:
+      $ref: ../schemas/Comment.yaml
+  last_page:
+    type: integer
+  current_page:
+    type: integer
+  next_page:
+    type:
+      - integer
+      - 'null'
+

--- a/docs/api_reference/reference/v2.1.0/schemas/requestBodies/Comment.yaml
+++ b/docs/api_reference/reference/v2.1.0/schemas/requestBodies/Comment.yaml
@@ -1,0 +1,7 @@
+type: object
+properties:
+  comment_text:
+    type: string
+example:
+  comment_text: 'Comment content'
+


### PR DESCRIPTION
Documentation of `DELETE /api/v2/{object}/{object_identifier}/comments/{identifier}`.
Deprecated `POST /{object}/{object_identifier}/comments/{identifier}`