### PR TITLE
Api v2 notes directories filter

### DIFF
--- a/docs/api_reference/reference/iris.v2.1.0.yaml
+++ b/docs/api_reference/reference/iris.v2.1.0.yaml
@@ -45,6 +45,7 @@ info:
     * Added GET /api/v2/cases/{case_identifier}/notes-directories/{identifier}
     * Added PUT /api/v2/cases/{case_identifier}/notes-directories/{identifier}
     * Added DELETE /api/v2/cases/{case_identifier}/notes-directories/{identifier}
+    * Added GET /api/v2/cases/{case_identifier}/notes-directories
     * Added POST /api/v2/cases/{case_identifier}/evidences
     * Added GET /api/v2/cases/{case_identifier}/evidences
     * Added GET /api/v2/cases/{case_identifier}/evidences/{identifier}

--- a/docs/api_reference/reference/iris.v2.1.0.yaml
+++ b/docs/api_reference/reference/iris.v2.1.0.yaml
@@ -94,6 +94,7 @@ info:
     * Deprecated POST /case/notes/update/{node_id} in favor of PUT /api/v2/cases/{case_identifier}/notes/{identifier}
     * Deprecated POST /case/notes/delete/{node_id} in favor of DELETE /api/v2/cases/{case_identifier}/notes/{identifier}
     * Deprecated POST /case/notes/directories/add in favor of POST /api/v2/cases/{case_identifier}/notes-directories
+    * Deprecated GET /case/notes/directories/filter in favor of GET /api/v2/cases/{case_identifier}/notes-directories
     * Deprecated POST /case/evidences/add in favor of POST /api/v2/cases/{case_identifier}/evidences
     * Deprecated GET /case/evidences/list in favor of GET /api/v2/cases/{case_identifier}/evidences
     * Deprecated GET /case/evidences/{evidence_id} in favor of GET /api/v2/cases/{case_identifier}/evidences/{identifier}

--- a/docs/api_reference/reference/v2.1.0/resources/api_v2_cases_{case_identifier}_notes-directories.yaml
+++ b/docs/api_reference/reference/v2.1.0/resources/api_v2_cases_{case_identifier}_notes-directories.yaml
@@ -30,3 +30,24 @@ post:
     '404':
       description: Case with identifier `case_identifier` not found
 
+get:
+  operationId: api_v2_cases_(case_identifier)_notes-directories_get
+  tags:
+    - Notes
+    - Beta
+  summary: Get notes directories filter
+  description: Return information of notes directories filter
+  responses:
+    '201':
+      description: notes directories filter successfully found
+      content:
+        application/json:
+          schema:
+            $ref: ../schemas/NoteDirectory.yaml
+    '400':
+      $ref: ../responses/GenericError.yaml
+    '403':
+      $ref: ../responses/Forbidden.yaml
+    '404':
+      $ref: ../responses/NotFound.yaml
+

--- a/docs/api_reference/reference/v2.1.0/resources/api_v2_cases_{case_identifier}_notes-directories.yaml
+++ b/docs/api_reference/reference/v2.1.0/resources/api_v2_cases_{case_identifier}_notes-directories.yaml
@@ -43,7 +43,7 @@ get:
       content:
         application/json:
           schema:
-            $ref: ../schemas/NoteDirectory.yaml
+            $ref: ../schemas/SearchNoteDirectory.yaml
     '400':
       $ref: ../responses/GenericError.yaml
     '403':

--- a/docs/api_reference/reference/v2.1.0/resources/case_notes_directories_filter.yaml
+++ b/docs/api_reference/reference/v2.1.0/resources/case_notes_directories_filter.yaml
@@ -506,7 +506,8 @@ get:
                         subdirectories: []
                     notes: []
   operationId: get-case-notes-directories
-  description: 'List the directories and notes associated to it. '
+  description: List the directories and notes associated to it.  Use [GET /api/v2/cases/{case_identifier}/notes-directories](#tag/Notes/operation/api_v2_cases_(case_identifier)_notes-directories_get) instead. 
+  deprecated: true
   security:
     - Bearer <bearer>: []
   parameters:

--- a/docs/api_reference/reference/v2.1.0/schemas/SearchNoteDirectory.yaml
+++ b/docs/api_reference/reference/v2.1.0/schemas/SearchNoteDirectory.yaml
@@ -1,0 +1,21 @@
+type: object
+properties:
+  id:
+    type: integer
+  name:
+    type: string
+  note_count:
+    type: 
+      - integer
+      - '0'
+  subdirectories:
+    type: array
+  notes:
+    type: array
+example:
+  id: 34
+  name: Test
+  note_count: 0
+  subdirectories: []
+  notes: []
+

--- a/docs/api_reference/reference/v2.1.0/schemas/SearchNoteDirectory.yaml
+++ b/docs/api_reference/reference/v2.1.0/schemas/SearchNoteDirectory.yaml
@@ -7,7 +7,7 @@ properties:
   note_count:
     type: 
       - integer
-      - '0'
+      - 0
   subdirectories:
     type: array
   notes:


### PR DESCRIPTION
Documentation of `GET /api/v2/cases/{case_identifier}/notes-directories`
Deprecation of `GET /case/notes/directories/filter`